### PR TITLE
Fix P0 foundation bugs across parser, descriptors, and API surface

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,166 @@
+# iso-kit Roadmap
+
+Status as of 2026-08-05, based on a full review of the codebase.
+
+## Current State
+
+The **read path is functional**: `Open()` correctly parses system areas, all volume descriptor
+types, El Torito boot catalogs, path tables (LE/BE), and directory trees with Rock Ridge and
+Joliet support. `Extract()` works. Marshal/Unmarshal round-trips exist for PVDs, SVDs, boot
+records, terminators, directory records, and path table records. ~9,600 lines across 43 files.
+
+The **write path is almost entirely non-functional**. `Create()` is commented out (returns a
+zero-value struct that nil-panics). `ReadFile()`, `AddFile()`, `RemoveFile()` all panic.
+`Save()` only re-serializes unmodified parsed ISOs at original byte offsets. No `Pack()` /
+layout engine, no mutable directory tree, no path table builder, no directory extent writer.
+
+Rock Ridge marshal is self-acknowledged as broken. El Torito marshal has incorrect field
+offsets. UDF is 37 panic stubs. 68 methods panic with "implement me". 144 TODO/FIXME markers.
+Test suite fails on main.
+
+## PR #4 (Copilot Agent) — Close Without Merging
+
+Cherry-pick only the option struct additions (`WithCreateRockRidgeEnabled`,
+`WithCreateElToritoEnabled`) and the go.mod change. Adopt the `pendingFiles` map concept
+and API shapes, but rewrite all implementations from scratch. See `docs/pr4-analysis.md`
+for the full breakdown.
+
+---
+
+## P0: Foundation — Bug Fixes & Read-Path Stability
+
+Goal: green test suite, read path that handles real-world ISOs without panicking.
+Every subsequent phase depends on these fixes.
+
+- [ ] Fix `DateTime` unmarshal for zero-filled (0x00) fields → return `time.Time{}`
+  - `pkg/iso9660/encoding/encoding.go` — `UnmarshalDateTime` only recognizes ASCII '0' (0x30)
+  - Unblocks the failing `TestPrimaryVolumeDescriptorBody_PreservesTrailingSpaces`
+- [ ] Fix SVD `LocationOfPathTableL()` — returns M-table location instead of L-table
+  - `pkg/iso9660/descriptor/supplementary.go:29` — one-line fix
+- [ ] Fix SVD `HasJoliet()` — unconditionally returns true
+  - `pkg/iso9660/descriptor/supplementary.go:94` — delegate to `IsJoliet()`
+- [ ] Fix terminator `Unmarshal` offset — never increments past reserved bytes
+  - `pkg/iso9660/descriptor/terminator.go:78` — add `offset += TERMINATOR_RESERVED_SIZE`
+- [ ] Fix `ListBootEntries()` nil dereference on non-bootable ISOs
+  - `pkg/iso9660/iso9660.go:430` — add `elTorito` nil check
+- [ ] Add nil-safety to all getter methods for `Create()` path
+  - `pkg/iso9660/iso9660.go:292-398` — 15+ methods deref `openOptions` without nil check
+- [ ] Fix `Extract()` file handle leak — `defer Close()` inside for loop
+  - `pkg/iso9660/iso9660.go:536` and `pkg/iso9660/boot/eltorito.go:464`
+- [ ] Fix `StripVersionInfo` — `TrimRight(";1")` → `TrimSuffix(";1")`
+  - `pkg/iso9660/iso9660.go:528`
+- [ ] Fix `Save()` sort overflow on large offsets — `int()` cast → `cmp.Compare`
+  - `pkg/iso9660/iso9660.go:661`
+- [ ] Replace panic stubs in `boot.go` and `partition.go` with zero-value returns
+  - `pkg/iso9660/descriptor/boot.go`, `partition.go` — 30+ panic stubs
+- [ ] Relax `UnmarshalFileFlags` reserved bit validation — warn instead of error
+  - `pkg/iso9660/directory/flags.go`
+- [ ] Relax `DirectoryRecord` padding byte validation — warn instead of error
+  - `pkg/iso9660/directory/record.go`
+- [ ] Fix `ReadDirectoryRecords` sectorBoundary tracking after zero-padding jump
+  - `pkg/iso9660/parser/parser.go:498-504`
+- [ ] Fix `SystemArea.ObjectSize` not set during `Open()`
+  - `pkg/iso9660/iso9660.go:49-55`
+- [ ] Remove unreachable code in `Save()` flagged by `go vet`
+  - `pkg/iso9660/iso9660.go:812`
+- [ ] Add Open→Save round-trip integration test
+  - Regression gate for all write-path work
+
+## P1: Core Write Path — Mutable Tree, Layout Engine, ISO Creation
+
+Goal: create and modify ISOs. Largest and most architecturally significant phase.
+
+- [ ] Design and implement mutable in-memory directory tree
+  - TreeNode with parent-child relationships, children map, pending data
+  - Insert, Remove, Lookup, Walk, BuildFromParsed methods
+  - Becomes single source of truth for filesystem state
+- [ ] Implement `ReadFile(path)`
+  - Search tree (or filesystemEntries), delegate to `GetBytes()` for existing files
+  - Return pendingFiles data for in-memory files
+- [ ] Implement `AddFile(path, data)` and `RemoveFile(path)`
+  - Tree-backed operations, create parent dirs as needed, store in pendingFiles
+  - Append ISO 9660 ";1" version suffix, maintain tree/flat-list consistency
+- [ ] Implement `AddDirectory(sourcePath, targetPath)`
+  - `filepath.Walk` with explicit directory records (. and ..) for subdirectories
+- [ ] Implement directory extent writer
+  - Marshal children into 2048-byte sectors, prepend . and .. entries
+  - Zero-pad at sector boundaries (records must not cross boundaries)
+- [ ] Implement path table builder from directory tree
+  - Breadth-first walk, sequential parent numbers, L-type and M-type output
+- [ ] Promote SVD numeric fields from raw byte arrays to typed values
+  - VolumeSpaceSize, VolumeSetSize, etc. — match PVD pattern
+  - Required for Pack() to update SVD programmatically
+- [ ] Implement `Pack()` — the sector layout engine
+  - Calculate descriptor area size (system area + PVD + optional boot/SVDs + terminator)
+  - Assign sector locations: path tables, directory extents (bottom-up), file data
+  - Update cross-references: VolumeSpaceSize, PathTableSize, LocationOfPathTable L/M,
+    each LocationOfExtent and DataLength
+  - Handle Joliet SVD layout separately
+- [ ] Implement `Create()` with proper initialization
+  - SystemArea, PVD with root DirectoryRecord, empty tree, terminator
+  - Optional Joliet SVD, fix getter nil-safety
+- [ ] Rewrite `Save()` for complete ISO output
+  - Pristine re-save (with gap padding) and modified/new ISO (Pack → full write)
+  - Pending files from memory, existing files from isoReader
+- [ ] Fix Joliet directory record marshal (UCS-2 re-encoding)
+  - When `dr.Joliet` is true, encode FileIdentifier as UCS-2
+- [ ] Add `VolumeDescriptorSet` methods (WriteTo, Validate)
+- [ ] Implement `VolumePartitionDescriptor` Marshal/Unmarshal
+- [ ] End-to-end Create→AddFile→Save→Open verification test
+
+## P2: Extensions — Rock Ridge, Joliet, El Torito Write Support
+
+Goal: proper extension support with spec-compliant serialization.
+
+- [ ] Implement SUSP framework (SP, CE, ER, ST, ES)
+  - Continuation areas for RR data exceeding System Use space
+- [ ] Rewrite `MarshalRockRidge` from scratch
+  - PX (36 bytes, both-endian), NM/SL (with flags), TF (7/17-byte ISO format),
+    CL/PL (both-endian), RR signature entry
+- [ ] Fix Rock Ridge unmarshal: add PN, CL, PL, RE, SF + fix TF/SL/NM parsing
+- [ ] Integrate Rock Ridge into write pipeline
+  - SP+ER in root, PX/NM/TF in every record, CE for overflow
+- [ ] Complete Joliet write support
+  - Separate UCS-2 directory tree, separate path tables, 64-char filename validation
+- [ ] Fix El Torito entry field offsets to match specification
+  - Byte 0 = Boot Indicator, byte 1 = Boot Media Type, bytes 2-3 = Load Segment
+- [ ] Fix El Torito marshal for multi-boot catalogs with section headers
+- [ ] Implement Boot Information Table support (56-byte table at offset 8)
+- [ ] Integrate El Torito into Create/Save pipeline
+- [ ] Wire character validation into descriptor write path
+- [ ] Implement ISO 9660 filename validation (Level 1/2/3)
+- [ ] Add multi-extent file assembly for reading (Level 3 / >4GB files)
+
+## P3: Advanced — UDF, Hybrid ISO, Production Readiness
+
+Goal: UDF support, USB-bootable hybrid ISOs, production CLI, comprehensive testing.
+
+- [ ] Fix UDF detection (scan Volume Recognition Sequence at sectors 16+)
+- [ ] UDF Volume Recognition Sequence and AVDP parsing
+- [ ] UDF volume descriptor and partition parsing (ECMA-167)
+- [ ] UDF file system traversal (FSD → ICB → File Entry → FID)
+- [ ] System area MBR partition table parsing and generation
+- [ ] GPT support for UEFI hybrid ISOs
+- [ ] Isohybrid post-processing (MBR + GPT after ISO build)
+- [ ] Rebuild `isocreate` CLI with proper argument parsing
+- [ ] Comprehensive unit tests (directory, parser, pathtable, extensions, eltorito)
+- [ ] CI pipeline (GitHub Actions) + README update
+- [ ] Split `VolumeDescriptor` interface into base + filesystem-aware sub-interface
+
+## Architectural Concerns
+
+These should be addressed early — they affect multiple work items:
+
+1. **No mutable directory tree** — flat `filesystemEntries` slice has no parent-child
+   relationships. Single biggest structural gap. Must be addressed before write-path work.
+2. **No parsed vs modified state separation** — need dirty-tracking. `Save()` must handle
+   both files backed by `io.ReaderAt` and files added in-memory.
+3. **VolumeDescriptor interface too broad** — forces boot records and terminators to
+   implement 20+ meaningless methods. Split into base + filesystem-aware sub-interface.
+4. **Separate OpenOptions / CreateOptions** — all getters only check `openOptions`.
+   Create()'d ISOs nil-panic on every getter. Unify or add fallback logic.
+5. **El Torito field offsets wrong** — parse and marshal share same incorrect layout.
+   Round-trips accidentally work but interop with other tools will corrupt boot catalogs.
+6. **Rock Ridge marshal acknowledged broken** — every entry type has encoding errors.
+   Complete rewrite needed.
+7. **SVD raw byte arrays** — VolumeSpaceSize etc. not typed. Pack() can't update them.

--- a/pkg/iso9660/descriptor/boot.go
+++ b/pkg/iso9660/descriptor/boot.go
@@ -26,83 +26,67 @@ func (d *BootRecordDescriptor) DescriptorType() VolumeDescriptorType {
 }
 
 func (d *BootRecordDescriptor) VolumeIdentifier() string {
-	//TODO implement me
-	panic("implement me")
+	return ""
 }
 
 func (d *BootRecordDescriptor) SystemIdentifier() string {
-	//TODO implement me
-	panic("implement me")
+	return ""
 }
 
 func (d *BootRecordDescriptor) VolumeSetIdentifier() string {
-	//TODO implement me
-	panic("implement me")
+	return ""
 }
 
 func (d *BootRecordDescriptor) PublisherIdentifier() string {
-	//TODO implement me
-	panic("implement me")
+	return ""
 }
 
 func (d *BootRecordDescriptor) DataPreparerIdentifier() string {
-	//TODO implement me
-	panic("implement me")
+	return ""
 }
 
 func (d *BootRecordDescriptor) ApplicationIdentifier() string {
-	//TODO implement me
-	panic("implement me")
+	return ""
 }
 
 func (d *BootRecordDescriptor) CopyrightFileIdentifier() string {
-	//TODO implement me
-	panic("implement me")
+	return ""
 }
 
 func (d *BootRecordDescriptor) AbstractFileIdentifier() string {
-	//TODO implement me
-	panic("implement me")
+	return ""
 }
 
 func (d *BootRecordDescriptor) BibliographicFileIdentifier() string {
-	//TODO implement me
-	panic("implement me")
+	return ""
 }
 
 func (d *BootRecordDescriptor) VolumeCreationDateTime() time.Time {
-	//TODO implement me
-	panic("implement me")
+	return time.Time{}
 }
 
 func (d *BootRecordDescriptor) VolumeModificationDateTime() time.Time {
-	//TODO implement me
-	panic("implement me")
+	return time.Time{}
 }
 
 func (d *BootRecordDescriptor) VolumeExpirationDateTime() time.Time {
-	//TODO implement me
-	panic("implement me")
+	return time.Time{}
 }
 
 func (d *BootRecordDescriptor) VolumeEffectiveDateTime() time.Time {
-	//TODO implement me
-	panic("implement me")
+	return time.Time{}
 }
 
 func (d *BootRecordDescriptor) HasJoliet() bool {
-	//TODO implement me
-	panic("implement me")
+	return false
 }
 
 func (d *BootRecordDescriptor) HasRockRidge() bool {
-	//TODO implement me
-	panic("implement me")
+	return false
 }
 
 func (d *BootRecordDescriptor) RootDirectory() *directory.DirectoryRecord {
-	//TODO implement me
-	panic("implement me")
+	return nil
 }
 
 func (d *BootRecordDescriptor) GetObjects() []info.ImageObject {

--- a/pkg/iso9660/descriptor/partition.go
+++ b/pkg/iso9660/descriptor/partition.go
@@ -24,83 +24,67 @@ func (d *VolumePartitionDescriptor) DescriptorType() VolumeDescriptorType {
 }
 
 func (d *VolumePartitionDescriptor) VolumeIdentifier() string {
-	//TODO implement me
-	panic("implement me")
+	return ""
 }
 
 func (d *VolumePartitionDescriptor) SystemIdentifier() string {
-	//TODO implement me
-	panic("implement me")
+	return ""
 }
 
 func (d *VolumePartitionDescriptor) VolumeSetIdentifier() string {
-	//TODO implement me
-	panic("implement me")
+	return ""
 }
 
 func (d *VolumePartitionDescriptor) PublisherIdentifier() string {
-	//TODO implement me
-	panic("implement me")
+	return ""
 }
 
 func (d *VolumePartitionDescriptor) DataPreparerIdentifier() string {
-	//TODO implement me
-	panic("implement me")
+	return ""
 }
 
 func (d *VolumePartitionDescriptor) ApplicationIdentifier() string {
-	//TODO implement me
-	panic("implement me")
+	return ""
 }
 
 func (d *VolumePartitionDescriptor) CopyrightFileIdentifier() string {
-	//TODO implement me
-	panic("implement me")
+	return ""
 }
 
 func (d *VolumePartitionDescriptor) AbstractFileIdentifier() string {
-	//TODO implement me
-	panic("implement me")
+	return ""
 }
 
 func (d *VolumePartitionDescriptor) BibliographicFileIdentifier() string {
-	//TODO implement me
-	panic("implement me")
+	return ""
 }
 
 func (d *VolumePartitionDescriptor) VolumeCreationDateTime() time.Time {
-	//TODO implement me
-	panic("implement me")
+	return time.Time{}
 }
 
 func (d *VolumePartitionDescriptor) VolumeModificationDateTime() time.Time {
-	//TODO implement me
-	panic("implement me")
+	return time.Time{}
 }
 
 func (d *VolumePartitionDescriptor) VolumeExpirationDateTime() time.Time {
-	//TODO implement me
-	panic("implement me")
+	return time.Time{}
 }
 
 func (d *VolumePartitionDescriptor) VolumeEffectiveDateTime() time.Time {
-	//TODO implement me
-	panic("implement me")
+	return time.Time{}
 }
 
 func (d *VolumePartitionDescriptor) HasJoliet() bool {
-	//TODO implement me
-	panic("implement me")
+	return false
 }
 
 func (d *VolumePartitionDescriptor) HasRockRidge() bool {
-	//TODO implement me
-	panic("implement me")
+	return false
 }
 
 func (d *VolumePartitionDescriptor) RootDirectory() *directory.DirectoryRecord {
-	//TODO implement me
-	panic("implement me")
+	return nil
 }
 
 func (d *VolumePartitionDescriptor) GetObjects() []info.ImageObject {

--- a/pkg/iso9660/descriptor/supplementary.go
+++ b/pkg/iso9660/descriptor/supplementary.go
@@ -26,7 +26,7 @@ func (d *SupplementaryVolumeDescriptor) DescriptorType() VolumeDescriptorType {
 }
 
 func (d *SupplementaryVolumeDescriptor) LocationOfPathTableL() uint32 {
-	return d.SupplementaryVolumeDescriptorBody.LocationOfTypeMPathTable
+	return d.SupplementaryVolumeDescriptorBody.LocationOfTypeLPathTable
 }
 
 func (d *SupplementaryVolumeDescriptor) LocationOfPathTableM() uint32 {
@@ -90,8 +90,7 @@ func (d *SupplementaryVolumeDescriptor) VolumeEffectiveDateTime() time.Time {
 }
 
 func (d *SupplementaryVolumeDescriptor) HasJoliet() bool {
-	// TODO: Should actually detect the Escape Sequences field to determine if Joliet is present.
-	return true
+	return d.SupplementaryVolumeDescriptorBody.IsJoliet()
 }
 
 func (d *SupplementaryVolumeDescriptor) HasRockRidge() bool {

--- a/pkg/iso9660/descriptor/terminator.go
+++ b/pkg/iso9660/descriptor/terminator.go
@@ -76,6 +76,7 @@ func (d *VolumeDescriptorSetTerminator) Unmarshal(data [consts.ISO9660_SECTOR_SI
 
 	// 2. Unmarshal the VolumeDescriptorSetTerminatorBody (remaining bytes).
 	copy(d.VolumeDescriptorSetTerminatorBody.Reserved[:], data[offset:offset+TERMINATOR_RESERVED_SIZE])
+	offset += TERMINATOR_RESERVED_SIZE
 
 	if offset != consts.ISO9660_SECTOR_SIZE {
 		return fmt.Errorf("unmarshal VolumeDescriptorSetTerminator: incorrect offset %d", offset)

--- a/pkg/iso9660/directory/flags.go
+++ b/pkg/iso9660/directory/flags.go
@@ -1,7 +1,5 @@
 package directory
 
-import "fmt"
-
 // FileFlags holds the flag values from a Directory Record's File Flags field.
 // The bits are numbered from 0 (LSB) to 7 (MSB) as follows:
 //
@@ -57,9 +55,7 @@ func (ff FileFlags) Marshal() byte {
 // UnmarshalFileFlags converts a byte into a FileFlags struct.
 // It returns an error if any reserved bits (bits 5 and 6) are nonzero.
 func UnmarshalFileFlags(b byte) (FileFlags, error) {
-	if b&0x60 != 0 { // Check reserved bits: 0x20 (bit 5) and 0x40 (bit 6)
-		return FileFlags{}, fmt.Errorf("invalid file flags: reserved bits must be zero, got 0x%02X", b)
-	}
+	// Reserved bits 5 and 6 are set by some older ISO authoring tools; tolerate them.
 	return FileFlags{
 		Hidden:         (b & 0x01) != 0,
 		Directory:      (b & 0x02) != 0,

--- a/pkg/iso9660/directory/record.go
+++ b/pkg/iso9660/directory/record.go
@@ -396,9 +396,7 @@ func (dr *DirectoryRecord) Unmarshal(data []byte) error {
 		if offset+1 > int(recordLength) {
 			return fmt.Errorf("insufficient data for padding byte")
 		}
-		if data[offset] != 0x00 {
-			return fmt.Errorf("expected padding byte 0x00, got 0x%02X", data[offset])
-		}
+		// Some ISO authoring tools write non-zero padding; tolerate it.
 		offset++
 	}
 

--- a/pkg/iso9660/encoding/encoding.go
+++ b/pkg/iso9660/encoding/encoding.go
@@ -73,12 +73,8 @@ func UnmarshalUint16LSBMSB(data [4]byte) (uint16, error) {
 func MarshalDateTime(t time.Time) ([17]byte, error) {
 	var out [17]byte
 
-	// If zero time => ASCII '0' x16 + final offset=0 => "unspecified"
+	// Zero time => all binary zeros (unspecified). Real ISOs use 0x00, not ASCII '0'.
 	if t.IsZero() {
-		for i := 0; i < 16; i++ {
-			out[i] = '0'
-		}
-		out[16] = 0
 		return out, nil
 	}
 
@@ -108,7 +104,18 @@ func MarshalDateTime(t time.Time) ([17]byte, error) {
 // YYYY MM DD hh mm ss cc, and the 17th byte as the offset in 15-minute intervals.
 // Note: This format is used in Volume Descriptors
 func UnmarshalDateTime(b [17]byte) (time.Time, error) {
-	// Detect "unspecified" => 16 ASCII '0' + offset=0
+	// Detect "unspecified" => all binary zeros (common in real ISOs) or 16 ASCII '0' + offset=0
+	allZero := true
+	for i := 0; i < 17; i++ {
+		if b[i] != 0 {
+			allZero = false
+			break
+		}
+	}
+	if allZero {
+		return time.Time{}, nil
+	}
+
 	isUnspecified := true
 	for i := 0; i < 16; i++ {
 		if b[i] != '0' {

--- a/pkg/iso9660/encoding/encoding_test.go
+++ b/pkg/iso9660/encoding/encoding_test.go
@@ -18,15 +18,16 @@ func TestISO9660DateTime(t *testing.T) {
 		}
 		zeros[16] = 0
 
-		// Unmarshal => zero time
+		// Unmarshal ASCII '0' form => zero time
 		tm, err := UnmarshalDateTime(zeros)
 		require.NoError(t, err)
 		require.True(t, tm.IsZero())
 
-		// Marshal that zero time => same 16 '0' + offset=0
+		// Marshal that zero time => binary zeros (real-world ISO convention)
 		reBytes, err := MarshalDateTime(tm)
 		require.NoError(t, err)
-		require.Equal(t, zeros, reBytes)
+		var binaryZeros [17]byte
+		require.Equal(t, binaryZeros, reBytes)
 	})
 
 	t.Run("RoundTripUTCOffset0", func(t *testing.T) {
@@ -80,7 +81,7 @@ func TestMarshalDateTime(t *testing.T) {
 		{
 			name:      "zero time",
 			timeVal:   time.Time{}, // t.IsZero() == true
-			wantBytes: "0000000000000000",
+			wantBytes: "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00",
 			wantOff:   0,
 			wantErr:   false,
 		},
@@ -135,11 +136,9 @@ func TestMarshalDateTime(t *testing.T) {
 			require.Equal(t, tt.wantOff, offset, "Mismatch in offset byte")
 
 			if tt.timeVal.IsZero() {
-				// For zero time, ensure all are ASCII '0'
-				for i := 0; i < 16; i++ {
-					require.Equal(t, byte('0'), got[i], "Expected zero-time to have '0' in each digit")
+				for i := 0; i < 17; i++ {
+					require.Equal(t, byte(0), got[i], "Expected zero-time to have 0x00 in each byte")
 				}
-				require.Equal(t, int8(0), offset, "Offset for zero time should be 0")
 			} else {
 				// Further optional checks: parse the date/time portions from gotStr
 				yyyy, _ := strconv.Atoi(gotStr[0:4])

--- a/pkg/iso9660/iso9660.go
+++ b/pkg/iso9660/iso9660.go
@@ -1,6 +1,7 @@
 package iso9660
 
 import (
+	"cmp"
 	"errors"
 	"fmt"
 	"github.com/bgrewell/iso-kit/pkg/consts"
@@ -51,7 +52,8 @@ func Open(isoReader io.ReaderAt, opts ...option.OpenOption) (*ISO9660, error) {
 		return nil, err
 	}
 	sa := systemarea.SystemArea{
-		Contents: saBuf,
+		Contents:   saBuf,
+		ObjectSize: consts.ISO9660_SECTOR_SIZE * consts.ISO9660_SYSTEM_AREA_SECTORS,
 	}
 
 	// Create a parser
@@ -288,117 +290,205 @@ type ISO9660 struct {
 	isPacked bool
 }
 
+func (iso *ISO9660) preferJoliet() bool {
+	return iso.openOptions != nil && iso.openOptions.PreferJoliet
+}
+
 // GetVolumeID returns the volume identifier of the ISO9660 filesystem.
 func (iso *ISO9660) GetVolumeID() string {
-	if iso.openOptions.PreferJoliet && iso.volumeDescriptorSet.Supplementary != nil {
+	if iso.volumeDescriptorSet == nil {
+		return ""
+	}
+	if iso.preferJoliet() && iso.volumeDescriptorSet.Supplementary != nil {
 		return iso.volumeDescriptorSet.Supplementary[0].VolumeIdentifier()
+	}
+	if iso.volumeDescriptorSet.Primary == nil {
+		return ""
 	}
 	return iso.volumeDescriptorSet.Primary.VolumeIdentifier()
 }
 
 // GetSystemID returns the system identifier of the ISO9660 filesystem.
 func (iso *ISO9660) GetSystemID() string {
-	if iso.openOptions.PreferJoliet && iso.volumeDescriptorSet.Supplementary != nil {
+	if iso.volumeDescriptorSet == nil {
+		return ""
+	}
+	if iso.preferJoliet() && iso.volumeDescriptorSet.Supplementary != nil {
 		return iso.volumeDescriptorSet.Supplementary[0].SystemIdentifier()
+	}
+	if iso.volumeDescriptorSet.Primary == nil {
+		return ""
 	}
 	return iso.volumeDescriptorSet.Primary.SystemIdentifier()
 }
 
 // GetVolumeSize returns the size of the ISO9660 filesystem.
 func (iso *ISO9660) GetVolumeSize() uint32 {
+	if iso.volumeDescriptorSet == nil || iso.volumeDescriptorSet.Primary == nil {
+		return 0
+	}
 	return iso.volumeDescriptorSet.Primary.VolumeSpaceSize
 }
 
 // GetVolumeSetID returns the volume set identifier of the ISO9660 filesystem.
 func (iso *ISO9660) GetVolumeSetID() string {
-	if iso.openOptions.PreferJoliet && iso.volumeDescriptorSet.Supplementary != nil {
+	if iso.volumeDescriptorSet == nil {
+		return ""
+	}
+	if iso.preferJoliet() && iso.volumeDescriptorSet.Supplementary != nil {
 		return iso.volumeDescriptorSet.Supplementary[0].VolumeSetIdentifier()
+	}
+	if iso.volumeDescriptorSet.Primary == nil {
+		return ""
 	}
 	return iso.volumeDescriptorSet.Primary.VolumeSetIdentifier()
 }
 
 // GetPublisherID returns the publisher identifier of the ISO9660 filesystem.
 func (iso *ISO9660) GetPublisherID() string {
-	if iso.openOptions.PreferJoliet && iso.volumeDescriptorSet.Supplementary != nil {
+	if iso.volumeDescriptorSet == nil {
+		return ""
+	}
+	if iso.preferJoliet() && iso.volumeDescriptorSet.Supplementary != nil {
 		return iso.volumeDescriptorSet.Supplementary[0].PublisherIdentifier()
+	}
+	if iso.volumeDescriptorSet.Primary == nil {
+		return ""
 	}
 	return iso.volumeDescriptorSet.Primary.PublisherIdentifier()
 }
 
 // GetDataPreparerID returns the data preparer identifier of the ISO9660 filesystem.
 func (iso *ISO9660) GetDataPreparerID() string {
-	if iso.openOptions.PreferJoliet && iso.volumeDescriptorSet.Supplementary != nil {
+	if iso.volumeDescriptorSet == nil {
+		return ""
+	}
+	if iso.preferJoliet() && iso.volumeDescriptorSet.Supplementary != nil {
 		return iso.volumeDescriptorSet.Supplementary[0].DataPreparerIdentifier()
+	}
+	if iso.volumeDescriptorSet.Primary == nil {
+		return ""
 	}
 	return iso.volumeDescriptorSet.Primary.DataPreparerIdentifier()
 }
 
 // GetApplicationID returns the application identifier of the ISO9660 filesystem.
 func (iso *ISO9660) GetApplicationID() string {
-	if iso.openOptions.PreferJoliet && iso.volumeDescriptorSet.Supplementary != nil {
+	if iso.volumeDescriptorSet == nil {
+		return ""
+	}
+	if iso.preferJoliet() && iso.volumeDescriptorSet.Supplementary != nil {
 		return iso.volumeDescriptorSet.Supplementary[0].ApplicationIdentifier()
+	}
+	if iso.volumeDescriptorSet.Primary == nil {
+		return ""
 	}
 	return iso.volumeDescriptorSet.Primary.ApplicationIdentifier()
 }
 
 // GetCopyrightID returns the copyright identifier of the ISO9660 filesystem.
 func (iso *ISO9660) GetCopyrightID() string {
-	if iso.openOptions.PreferJoliet && iso.volumeDescriptorSet.Supplementary != nil {
+	if iso.volumeDescriptorSet == nil {
+		return ""
+	}
+	if iso.preferJoliet() && iso.volumeDescriptorSet.Supplementary != nil {
 		return iso.volumeDescriptorSet.Supplementary[0].CopyrightFileIdentifier()
+	}
+	if iso.volumeDescriptorSet.Primary == nil {
+		return ""
 	}
 	return iso.volumeDescriptorSet.Primary.CopyrightFileIdentifier()
 }
 
 // GetAbstractID returns the abstract identifier of the ISO9660 filesystem.
 func (iso *ISO9660) GetAbstractID() string {
-	if iso.openOptions.PreferJoliet && iso.volumeDescriptorSet.Supplementary != nil {
+	if iso.volumeDescriptorSet == nil {
+		return ""
+	}
+	if iso.preferJoliet() && iso.volumeDescriptorSet.Supplementary != nil {
 		return iso.volumeDescriptorSet.Supplementary[0].AbstractFileIdentifier()
+	}
+	if iso.volumeDescriptorSet.Primary == nil {
+		return ""
 	}
 	return iso.volumeDescriptorSet.Primary.AbstractFileIdentifier()
 }
 
 // GetBibliographicID returns the bibliographic identifier of the ISO9660 filesystem.
 func (iso *ISO9660) GetBibliographicID() string {
-	if iso.openOptions.PreferJoliet && iso.volumeDescriptorSet.Supplementary != nil {
+	if iso.volumeDescriptorSet == nil {
+		return ""
+	}
+	if iso.preferJoliet() && iso.volumeDescriptorSet.Supplementary != nil {
 		return iso.volumeDescriptorSet.Supplementary[0].BibliographicFileIdentifier()
+	}
+	if iso.volumeDescriptorSet.Primary == nil {
+		return ""
 	}
 	return iso.volumeDescriptorSet.Primary.BibliographicFileIdentifier()
 }
 
 // GetCreationDateTime returns the creation date and time of the ISO9660 filesystem.
 func (iso *ISO9660) GetCreationDateTime() time.Time {
-	if iso.openOptions.PreferJoliet && iso.volumeDescriptorSet.Supplementary != nil {
+	if iso.volumeDescriptorSet == nil {
+		return time.Time{}
+	}
+	if iso.preferJoliet() && iso.volumeDescriptorSet.Supplementary != nil {
 		return iso.volumeDescriptorSet.Supplementary[0].VolumeCreationDateTime()
+	}
+	if iso.volumeDescriptorSet.Primary == nil {
+		return time.Time{}
 	}
 	return iso.volumeDescriptorSet.Primary.VolumeCreationDateTime()
 }
 
 // GetModificationDateTime returns the modification date and time of the ISO9660 filesystem.
 func (iso *ISO9660) GetModificationDateTime() time.Time {
-	if iso.openOptions.PreferJoliet && iso.volumeDescriptorSet.Supplementary != nil {
+	if iso.volumeDescriptorSet == nil {
+		return time.Time{}
+	}
+	if iso.preferJoliet() && iso.volumeDescriptorSet.Supplementary != nil {
 		return iso.volumeDescriptorSet.Supplementary[0].VolumeModificationDateTime()
+	}
+	if iso.volumeDescriptorSet.Primary == nil {
+		return time.Time{}
 	}
 	return iso.volumeDescriptorSet.Primary.VolumeModificationDateTime()
 }
 
 // GetExpirationDateTime returns the expiration date and time of the ISO9660 filesystem.
 func (iso *ISO9660) GetExpirationDateTime() time.Time {
-	if iso.openOptions.PreferJoliet && iso.volumeDescriptorSet.Supplementary != nil {
+	if iso.volumeDescriptorSet == nil {
+		return time.Time{}
+	}
+	if iso.preferJoliet() && iso.volumeDescriptorSet.Supplementary != nil {
 		return iso.volumeDescriptorSet.Supplementary[0].VolumeExpirationDateTime()
+	}
+	if iso.volumeDescriptorSet.Primary == nil {
+		return time.Time{}
 	}
 	return iso.volumeDescriptorSet.Primary.VolumeExpirationDateTime()
 }
 
 // GetEffectiveDateTime returns the effective date and time of the ISO9660 filesystem.
 func (iso *ISO9660) GetEffectiveDateTime() time.Time {
-	if iso.openOptions.PreferJoliet && iso.volumeDescriptorSet.Supplementary != nil {
+	if iso.volumeDescriptorSet == nil {
+		return time.Time{}
+	}
+	if iso.preferJoliet() && iso.volumeDescriptorSet.Supplementary != nil {
 		return iso.volumeDescriptorSet.Supplementary[0].VolumeEffectiveDateTime()
+	}
+	if iso.volumeDescriptorSet.Primary == nil {
+		return time.Time{}
 	}
 	return iso.volumeDescriptorSet.Primary.VolumeEffectiveDateTime()
 }
 
 // HasJoliet returns true if the ISO9660 filesystem has Joliet extensions.
 func (iso *ISO9660) HasJoliet() bool {
+	if iso.volumeDescriptorSet == nil {
+		return false
+	}
 	for _, svd := range iso.volumeDescriptorSet.Supplementary {
 		if svd.HasJoliet() {
 			return true
@@ -409,6 +499,9 @@ func (iso *ISO9660) HasJoliet() bool {
 
 // HasRockRidge returns true if the ISO9660 filesystem has Rock Ridge extensions.
 func (iso *ISO9660) HasRockRidge() bool {
+	if iso.volumeDescriptorSet == nil || iso.volumeDescriptorSet.Primary == nil {
+		return false
+	}
 	return iso.volumeDescriptorSet.Primary.HasRockRidge()
 }
 
@@ -419,14 +512,23 @@ func (iso *ISO9660) HasElTorito() bool {
 
 // RootDirectoryLocation returns the location of the root directory in the ISO9660 filesystem.
 func (iso *ISO9660) RootDirectoryLocation() uint32 {
-	if iso.openOptions.PreferJoliet && iso.volumeDescriptorSet.Supplementary != nil {
+	if iso.volumeDescriptorSet == nil {
+		return 0
+	}
+	if iso.preferJoliet() && iso.volumeDescriptorSet.Supplementary != nil {
 		return iso.volumeDescriptorSet.Supplementary[0].RootDirectoryRecord.LocationOfExtent
+	}
+	if iso.volumeDescriptorSet.Primary == nil || iso.volumeDescriptorSet.Primary.RootDirectoryRecord == nil {
+		return 0
 	}
 	return iso.volumeDescriptorSet.Primary.RootDirectoryRecord.LocationOfExtent
 }
 
 // ListBootEntries returns a list of all boot entries in the ISO9660 filesystem.
 func (iso *ISO9660) ListBootEntries() ([]*filesystem.FileSystemEntry, error) {
+	if iso.elTorito == nil {
+		return nil, nil
+	}
 	return iso.elTorito.BuildBootImageEntries()
 }
 
@@ -525,63 +627,63 @@ func (iso *ISO9660) Extract(path string) error {
 
 		// if the option to strip version info is enabled, enhanced and rr are not enabled then strip the version info
 		if iso.openOptions.StripVersionInfo && !iso.openOptions.RockRidgeEnabled && !iso.openOptions.PreferJoliet {
-			outputPath = strings.TrimRight(outputPath, ";1")
+			outputPath = strings.TrimSuffix(outputPath, ";1")
 		}
 
-		// Open output file for writing
-		outFile, err := os.Create(outputPath)
-		if err != nil {
-			return fmt.Errorf("failed to create file %s: %w", outputPath, err)
+		if err := iso.extractFile(entry, outputPath, i+1, totalFiles); err != nil {
+			return err
 		}
-		defer outFile.Close()
+	}
 
-		// Stream the file from the ISO
-		startOffset := int64(entry.Location) * int64(consts.ISO9660_SECTOR_SIZE)
-		size := int64(entry.Size)
-		bufferSize := 4096 // 4KB buffer
-		buffer := make([]byte, bufferSize)
+	return nil
+}
 
-		var bytesTransferred int64
-		for bytesTransferred < size {
-			// Read chunk from ISO
-			bytesToRead := bufferSize
-			if remaining := size - bytesTransferred; remaining < int64(bufferSize) {
-				bytesToRead = int(remaining)
-			}
+func (iso *ISO9660) extractFile(entry *filesystem.FileSystemEntry, outputPath string, fileNum, totalFiles int) error {
+	outFile, err := os.Create(outputPath)
+	if err != nil {
+		return fmt.Errorf("failed to create file %s: %w", outputPath, err)
+	}
+	defer outFile.Close()
 
-			n, err := entry.ReadAt(buffer[:bytesToRead], startOffset+bytesTransferred)
-			if err != nil && err != io.EOF {
-				return fmt.Errorf("failed to read file %s from ISO: %w", entry.FullPath, err)
-			}
+	startOffset := int64(entry.Location) * int64(consts.ISO9660_SECTOR_SIZE)
+	size := int64(entry.Size)
+	bufferSize := 4096
+	buffer := make([]byte, bufferSize)
 
-			if n == 0 {
-				break // Reached EOF
-			}
-
-			// Write chunk to file
-			if _, err := outFile.Write(buffer[:n]); err != nil {
-				return fmt.Errorf("failed to write to file %s: %w", outputPath, err)
-			}
-
-			// Update bytes transferred
-			bytesTransferred += int64(n)
-
-			// Invoke progress callback
-			if iso.openOptions.ExtractionProgressCallback != nil {
-				iso.openOptions.ExtractionProgressCallback(outputPath, bytesTransferred, size, i+1, totalFiles)
-			}
+	var bytesTransferred int64
+	for bytesTransferred < size {
+		bytesToRead := bufferSize
+		if remaining := size - bytesTransferred; remaining < int64(bufferSize) {
+			bytesToRead = int(remaining)
 		}
 
-		// Set correct file permissions
-		if err := os.Chmod(outputPath, entry.Mode); err != nil {
-			return fmt.Errorf("failed to set permissions on %s: %w", outputPath, err)
+		n, err := entry.ReadAt(buffer[:bytesToRead], startOffset+bytesTransferred)
+		if err != nil && err != io.EOF {
+			return fmt.Errorf("failed to read file %s from ISO: %w", entry.FullPath, err)
 		}
 
-		// Set timestamps
-		if !entry.ModTime.IsZero() {
-			if err := os.Chtimes(outputPath, entry.ModTime, entry.ModTime); err != nil {
-				return fmt.Errorf("failed to set timestamps on %s: %w", outputPath, err)
-			}
+		if n == 0 {
+			break
+		}
+
+		if _, err := outFile.Write(buffer[:n]); err != nil {
+			return fmt.Errorf("failed to write to file %s: %w", outputPath, err)
+		}
+
+		bytesTransferred += int64(n)
+
+		if iso.openOptions != nil && iso.openOptions.ExtractionProgressCallback != nil {
+			iso.openOptions.ExtractionProgressCallback(outputPath, bytesTransferred, size, fileNum, totalFiles)
+		}
+	}
+
+	if err := os.Chmod(outputPath, entry.Mode); err != nil {
+		return fmt.Errorf("failed to set permissions on %s: %w", outputPath, err)
+	}
+
+	if !entry.ModTime.IsZero() {
+		if err := os.Chtimes(outputPath, entry.ModTime, entry.ModTime); err != nil {
+			return fmt.Errorf("failed to set timestamps on %s: %w", outputPath, err)
 		}
 	}
 
@@ -658,7 +760,7 @@ func (iso *ISO9660) Save(writer io.WriterAt) error {
 
 	// Sort objects by offset before writing
 	slices.SortFunc(objects, func(a, b info.ImageObject) int {
-		return int(a.Offset() - b.Offset())
+		return cmp.Compare(a.Offset(), b.Offset())
 	})
 
 	// Write each object at its assigned offset
@@ -677,139 +779,6 @@ func (iso *ISO9660) Save(writer io.WriterAt) error {
 	}
 
 	return nil
-
-	//sectorSize := int64(consts.ISO9660_SECTOR_SIZE)
-	//saOffset := int64(0)
-	//
-	//// Calculate offsets for descriptors
-	//pvdSize := sectorSize
-	//bootSize := int64(0)
-	//if iso.bootRecord != nil {
-	//	bootSize = sectorSize
-	//}
-	//svdSize := int64(len(iso.svds)) * sectorSize
-	//ptvdSize := int64(len(iso.partitionvds)) * sectorSize
-	//
-	//pvdOffset := saOffset + consts.ISO9660_SYSTEM_AREA_SECTORS*sectorSize
-	//bootOffset := pvdOffset + pvdSize
-	//svdOffset := bootOffset + bootSize
-	//ptvdOffset := svdOffset + svdSize
-	//termOffset := ptvdOffset + ptvdSize
-	//
-	//type descriptorSetEntry struct {
-	//	descriptor descriptor.VolumeDescriptor
-	//	offset     int64
-	//}
-	//descriptorSet := []*descriptorSetEntry{
-	//	{descriptor: iso.pvd, offset: pvdOffset},
-	//}
-	//if iso.bootRecord != nil {
-	//	descriptorSet = append(descriptorSet,
-	//		&descriptorSetEntry{descriptor: iso.bootRecord, offset: bootOffset},
-	//	)
-	//}
-	//for i, svd := range iso.svds {
-	//	descriptorSet = append(descriptorSet,
-	//		&descriptorSetEntry{descriptor: svd, offset: svdOffset + int64(i)*sectorSize},
-	//	)
-	//}
-	//for i, ptvd := range iso.partitionvds {
-	//	descriptorSet = append(descriptorSet,
-	//		&descriptorSetEntry{descriptor: ptvd, offset: ptvdOffset + int64(i)*sectorSize},
-	//	)
-	//}
-	//descriptorSet = append(descriptorSet,
-	//	&descriptorSetEntry{descriptor: descriptor.NewVolumeDescriptorSetTerminator(), offset: termOffset})
-	//
-	//// Write system area
-	//_, err := writer.WriteAt(iso.systemArea.Contents[:], 0)
-	//if err != nil {
-	//	return err
-	//}
-	//
-	//// Write descriptor set
-	//for _, entry := range descriptorSet {
-	//	if err = writeDescriptor(writer, entry.descriptor, entry.offset); err != nil {
-	//		return err
-	//	}
-	//}
-	//
-	//// Write path tables according to their location in the volume descriptors
-	//err = iso.writePathTables(writer)
-	//if err != nil {
-	//	return err
-	//}
-
-	// Write directory records
-
-	//pathTableOffset := svdOffset + (len(iso.svds) * sectorSize)
-	//// Directory Record offsets should be
-	//
-	//
-
-	//// TODO: Clean up all of the offset calculations, instead this should be calculated somewhere
-	////       else and the locations should just be used to write the data or this should be wrapped
-	////       nicely in a function.
-	//// Write volume descriptor set
-	//pvdOffset := int64(16 * sectorSize)
-	//err = writeDescriptor(writer, iso.pvd, pvdOffset)
-	//if err != nil {
-	//	return err
-	//}
-	//
-	//svdOffset := pvdOffset + int64(1*sectorSize)
-	//for i, svd := range iso.svds {
-	//	err = writeDescriptor(writer, svd, svdOffset)
-	//	if err != nil {
-	//		return err
-	//	}
-	//	svdOffset = svdOffset+int64((i+1)*sectorSize)
-	//}
-	//
-	//ptvdOffset := svdOffset
-	//for i, pvd := range iso.partitionvds {
-	//	if err = writeDescriptor(writer, pvd, ptvdOffset); err != nil {
-	//		return err
-	//	}
-	//	ptvdOffset = ptvdOffset+int64((i+1)*sectorSize)
-	//}
-	//
-	//bootOffset := ptvdOffset
-	//if iso.bootRecord != nil {
-	//	if err = writeDescriptor(writer, iso.bootRecord, bootOffset); err != nil {
-	//		return err
-	//	}
-	//	bootOffset = bootOffset + int64(1*sectorSize)
-	//}
-	//
-	//tr := descriptor.NewVolumeDescriptorSetTerminator()
-	//if err := writeDescriptor(writer, tr, bootOffset); err != nil {
-	//	return err
-	//}
-
-	//// 3: Write path tables (Little & Big Endian versions)
-	//if err = iso.writePathTables(writer); err != nil {
-	//	return err
-	//}
-	//
-	//// 4: Write directory records (Root & Subdirectories)
-	//totalRecords := append(iso.pvdDirectoryRecords, iso.svdDirectoryRecords...)
-	//for i, dr := range totalRecords {
-	//	drOffset :=
-	//}
-	//
-	//
-	//// 5: Write file contents (Ensuring correct logical block placement)
-	//if err := iso.writeFileData(writer); err != nil {
-	//	return err
-	//}
-	//
-	//// 6: Align to sector size (Padding to 2048-byte boundaries)
-	//if err := padToSector(writer); err != nil {
-	//	return err
-	//}
-
-	return nil
 }
 
 // Close closes the ISO9660 filesystem.
@@ -818,143 +787,6 @@ func (iso *ISO9660) Close() error {
 		return f.Close()
 	}
 	return nil
-}
-
-// writePathTables writes the path tables to the ISO9660 filesystem.
-func (iso *ISO9660) writePathTables(writer io.WriterAt) error {
-	//if iso.pvd == nil {
-	//	return errors.New("PVD is missing")
-	//}
-	//
-	//buf, err := iso.pvdLPathTable.Marshal(true)
-	//if err != nil {
-	//	return err
-	//}
-	//
-	//if _, err = writer.WriteAt(buf, int64(iso.pvd.LocationOfTypeLPathTable)*consts.ISO9660_SECTOR_SIZE); err != nil {
-	//	return err
-	//}
-	//
-	//buf, err = iso.pvdMPathTable.Marshal(false)
-	//if err != nil {
-	//	return err
-	//}
-	//
-	//if _, err = writer.WriteAt(buf, int64(iso.pvd.LocationOfTypeMPathTable)*consts.ISO9660_SECTOR_SIZE); err != nil {
-	//	return err
-	//}
-	//
-	//if iso.svdLPathTable != nil {
-	//	buf, err = iso.svdLPathTable.Marshal(true)
-	//	if err != nil {
-	//		return err
-	//	}
-	//
-	//	if _, err = writer.WriteAt(buf, int64(iso.svds[0].LocationOfTypeLPathTable)*consts.ISO9660_SECTOR_SIZE); err != nil {
-	//		return err
-	//	}
-	//}
-	//
-	//if iso.svdMPathTable != nil {
-	//	buf, err = iso.svdMPathTable.Marshal(false)
-	//	if err != nil {
-	//		return err
-	//	}
-	//
-	//	if _, err = writer.WriteAt(buf, int64(iso.svds[0].LocationOfTypeMPathTable)*consts.ISO9660_SECTOR_SIZE); err != nil {
-	//		return err
-	//	}
-	//}
-
-	return nil
-}
-
-func (iso *ISO9660) writeDirectoryRecords(writer io.WriterAt) error {
-
-	//var rootDirOffset uint32
-	//
-	//// TODO: Write PVD Directory records starting with the root
-	//rootDirOffset = iso.pvd.RootDirectoryRecord.LocationOfExtent
-
-	// TODO: Write SVD Directory records starting with the root
-
-	//sectorSize := consts.ISO9660_SECTOR_SIZE
-	//
-	//// Root Directory
-	//rootDirData, err := iso.
-	//if err != nil {
-	//	return err
-	//}
-	//if _, err := writer.Write(rootDirData[:]); err != nil {
-	//	return err
-	//}
-	//
-	//// Write Subdirectories
-	//for _, dir := range iso.directories {
-	//	dirData, err := dir.Marshal()
-	//	if err != nil {
-	//		return err
-	//	}
-	//
-	//	// Ensure correct sector alignment
-	//	padding := sectorSize - (len(dirData) % sectorSize)
-	//	if padding < sectorSize {
-	//		dirData = append(dirData, make([]byte, padding)...)
-	//	}
-	//
-	//	if _, err := writer.Write(dirData[:]); err != nil {
-	//		return err
-	//	}
-	//}
-	//
-	//return nil
-	return errors.New("not implemented")
-}
-
-func (iso *ISO9660) writeFileData(writer io.Writer) error {
-	//sectorSize := consts.ISO9660_SECTOR_SIZE
-	//
-	//for _, file := range iso. {
-	//	fileData, err := file.ReadData()
-	//	if err != nil {
-	//		return err
-	//	}
-	//
-	//	if _, err := writer.Write(fileData); err != nil {
-	//		return err
-	//	}
-	//
-	//	// Align to sector size
-	//	padding := sectorSize - (len(fileData) % sectorSize)
-	//	if padding < sectorSize {
-	//		if _, err := writer.Write(make([]byte, padding)); err != nil {
-	//			return err
-	//		}
-	//	}
-	//}
-	//
-	//return nil
-	return errors.New("not implemented")
-}
-
-func padToSector(writer io.Writer) error {
-	//sectorSize := consts.ISO9660_SECTOR_SIZE
-	//
-	//// Get current file position
-	//offset, err := writer.Seek(0, io.SeekCurrent)
-	//if err != nil {
-	//	return err
-	//}
-	//
-	//// Compute padding
-	//padding := sectorSize - (offset % sectorSize)
-	//if padding < sectorSize {
-	//	_, err := writer.Write(make([]byte, padding))
-	//	return err
-	//}
-	//
-	//return nil
-	return errors.New("not implemented")
 }
 
 func writeDescriptor(writer io.WriterAt, descriptor descriptor.VolumeDescriptor, offset int64) error {
@@ -972,17 +804,4 @@ func writeDescriptor(writer io.WriterAt, descriptor descriptor.VolumeDescriptor,
 	}
 
 	return nil
-}
-
-func writePathTable(writer io.Writer, location uint32, littleEndian bool) error {
-	//if location == 0 {
-	//	return nil // Skip if no path table is set
-	//}
-	//
-	//pathTable := generatePathTable(littleEndian) // Implement the path table generator
-	//data := pathTable.Marshal()
-	//
-	//_, err := writer.Write(data)
-	//return err
-	return errors.New("not implemented")
 }

--- a/pkg/iso9660/parser/parser.go
+++ b/pkg/iso9660/parser/parser.go
@@ -500,7 +500,8 @@ func (p *Parser) ReadDirectoryRecords(lba uint32, dataLength uint32, joliet bool
 				break // End of directory data
 			}
 			p.logger.Trace("Moving to next sector", "sector", nextSector)
-			index = nextSector // Align to next sector
+			index = nextSector
+			sectorBoundary = nextSector + sectorSize
 			continue
 		}
 


### PR DESCRIPTION
## Summary

First phase (P0) of the roadmap in `docs/ROADMAP.md`: foundation bug fixes that stabilize the read path and remove crash hazards before write/create work begins.

### Crash fixes
- Replace 30 `panic("implement me")` stubs in the boot record and partition descriptors with zero-value returns (same pattern as the terminator descriptor). Opening any ISO containing a boot record no longer risks a panic when iterating descriptors.
- Add nil-safety guards to all top-level getters (`GetVolumeID`, `GetSystemID`, etc.), `HasJoliet`, `HasRockRidge`, `RootDirectoryLocation`, and `ListBootEntries`.

### Correctness fixes
- `UnmarshalDateTime` now accepts binary zero-filled (0x00) date fields, which most real-world ISOs use for unspecified dates; `MarshalDateTime` emits binary zeros for zero times to match. Round-trips of real images now preserve bytes exactly.
- SVD `LocationOfPathTableL()` returned the M-table location; `HasJoliet()` unconditionally returned true.
- Terminator `Unmarshal` did not advance its offset past the reserved area, failing its own size check.
- Parser sector-boundary tracking was not updated after jumping past zero padding, causing false "record crosses sector boundary" retries in multi-sector directories.
- `StripVersionInfo` used `TrimRight(";1")` which also strips trailing 1s and semicolons from names; now `TrimSuffix`.
- `Save` object sort used `int(a.Offset() - b.Offset())`, which can overflow on large images; now `cmp.Compare`.
- `SystemArea.ObjectSize` is now set during `Open()`.
- `Extract` leaked file handles by deferring closes inside a loop; per-file logic moved into a helper so defers run per file.

### Robustness
- Tolerate reserved file-flag bits (5 & 6) and non-zero directory record padding written by older authoring tools instead of failing the whole parse.

### Cleanup
- Removed ~200 lines of unreachable commented-out write-path code and dead helpers from `iso9660.go`.
- Added `docs/ROADMAP.md` documenting the phased plan (P0–P3) toward full open/modify/create support, Rock Ridge, UDF, and hybrid ISOs.

## Test plan
- `go build ./...`, `go vet ./...` clean
- `go test ./...` passes, including the previously failing datetime unmarshal test and the PVD byte-exact round-trip test
- Encoding tests updated to reflect the binary-zero convention for unspecified dates