### PR TITLE
Add core write path: mutable tree, layout engine, Create and Save

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -70,43 +70,49 @@ Every subsequent phase depends on these fixes.
 
 Goal: create and modify ISOs. Largest and most architecturally significant phase.
 
-- [ ] Design and implement mutable in-memory directory tree
-  - TreeNode with parent-child relationships, children map, pending data
-  - Insert, Remove, Lookup, Walk, BuildFromParsed methods
-  - Becomes single source of truth for filesystem state
-- [ ] Implement `ReadFile(path)`
-  - Search tree (or filesystemEntries), delegate to `GetBytes()` for existing files
-  - Return pendingFiles data for in-memory files
-- [ ] Implement `AddFile(path, data)` and `RemoveFile(path)`
-  - Tree-backed operations, create parent dirs as needed, store in pendingFiles
-  - Append ISO 9660 ";1" version suffix, maintain tree/flat-list consistency
-- [ ] Implement `AddDirectory(sourcePath, targetPath)`
-  - `filepath.Walk` with explicit directory records (. and ..) for subdirectories
-- [ ] Implement directory extent writer
-  - Marshal children into 2048-byte sectors, prepend . and .. entries
-  - Zero-pad at sector boundaries (records must not cross boundaries)
-- [ ] Implement path table builder from directory tree
+- [x] Design and implement mutable in-memory directory tree (`pkg/iso9660/tree`)
+  - Node with parent-child relationships, children map, pending data
+  - AddFile, AddDirectory, AddExistingFile, Remove, Lookup, Walk, Directories
+  - Built from parsed entries during Open; single source of truth for Save
+- [x] Implement `ReadFile(path)`
+  - Tree lookup; pending data from memory, existing content streamed from the
+    backing image
+- [x] Implement `AddFile(path, data)` and `RemoveFile(path)`
+  - Tree-backed, create parent dirs as needed; ";1" version suffix appended at
+    marshal time; flat entry list rebuilt lazily from the tree after mutation
+  - Also: `AddDirectory(path)`, `RemoveDirectory(path)`
+- [x] Implement `AddLocalDirectory(sourcePath, targetPath)`
+  - `filepath.Walk` import of a local directory tree, preserving mode/mtime
+- [x] Implement directory extent writer (`pack.go: marshalDirectoryExtent`)
+  - Marshals children into 2048-byte sectors with . and .. entries
+  - Zero-pads at sector boundaries (records never cross boundaries)
+- [x] Implement path table builder from directory tree (`pack.go: buildPathTables`)
   - Breadth-first walk, sequential parent numbers, L-type and M-type output
 - [ ] Promote SVD numeric fields from raw byte arrays to typed values
   - VolumeSpaceSize, VolumeSetSize, etc. — match PVD pattern
-  - Required for Pack() to update SVD programmatically
-- [ ] Implement `Pack()` — the sector layout engine
-  - Calculate descriptor area size (system area + PVD + optional boot/SVDs + terminator)
-  - Assign sector locations: path tables, directory extents (bottom-up), file data
-  - Update cross-references: VolumeSpaceSize, PathTableSize, LocationOfPathTable L/M,
-    each LocationOfExtent and DataLength
-  - Handle Joliet SVD layout separately
-- [ ] Implement `Create()` with proper initialization
+  - Required for Pack() to update SVD programmatically (needed for Joliet write, P2)
+- [x] Implement `Pack()` — the sector layout engine
+  - Assigns sector locations: PVD, terminator, path tables, directory extents
+    (breadth-first), file data
+  - Updates cross-references: VolumeSpaceSize, PathTableSize, LocationOfPathTable
+    L/M, root record location/length, each extent's LocationOfExtent/DataLength
+  - Joliet SVD layout deferred to P2 (SVDs are dropped from rebuilt output with a
+    logged warning)
+- [x] Implement `Create()` with proper initialization
   - SystemArea, PVD with root DirectoryRecord, empty tree, terminator
-  - Optional Joliet SVD, fix getter nil-safety
-- [ ] Rewrite `Save()` for complete ISO output
-  - Pristine re-save (with gap padding) and modified/new ISO (Pack → full write)
-  - Pending files from memory, existing files from isoReader
+  - Joliet SVD deferred to P2 (warned when requested)
+- [x] Rewrite `Save()` for complete ISO output
+  - Pristine passthrough for unmodified opened images; Pack → full rebuild for
+    created/modified images
+  - Pending files written from memory, existing files streamed from isoReader
+    (relocation-safe)
 - [ ] Fix Joliet directory record marshal (UCS-2 re-encoding)
-  - When `dr.Joliet` is true, encode FileIdentifier as UCS-2
+  - When `dr.Joliet` is true, encode FileIdentifier as UCS-2 (with P2 Joliet work)
 - [ ] Add `VolumeDescriptorSet` methods (WriteTo, Validate)
 - [ ] Implement `VolumePartitionDescriptor` Marshal/Unmarshal
-- [ ] End-to-end Create→AddFile→Save→Open verification test
+- [x] End-to-end Create→AddFile→Save→Open verification test
+  - Round-trip tests plus Open→modify→Save→Open, multi-sector directories,
+    empty images, and external-tool interop (isoinfo/xorriso)
 
 ## P2: Extensions — Rock Ridge, Joliet, El Torito Write Support
 

--- a/pkg/iso9660/iso9660.go
+++ b/pkg/iso9660/iso9660.go
@@ -8,10 +8,12 @@ import (
 	"github.com/bgrewell/iso-kit/pkg/filesystem"
 	"github.com/bgrewell/iso-kit/pkg/iso9660/boot"
 	"github.com/bgrewell/iso-kit/pkg/iso9660/descriptor"
+	"github.com/bgrewell/iso-kit/pkg/iso9660/directory"
 	"github.com/bgrewell/iso-kit/pkg/iso9660/info"
 	"github.com/bgrewell/iso-kit/pkg/iso9660/parser"
 	"github.com/bgrewell/iso-kit/pkg/iso9660/pathtable"
 	"github.com/bgrewell/iso-kit/pkg/iso9660/systemarea"
+	"github.com/bgrewell/iso-kit/pkg/iso9660/tree"
 	"github.com/bgrewell/iso-kit/pkg/logging"
 	"github.com/bgrewell/iso-kit/pkg/option"
 	"github.com/bgrewell/iso-kit/pkg/version"
@@ -142,6 +144,26 @@ func Open(isoReader io.ReaderAt, opts ...option.OpenOption) (*ISO9660, error) {
 		Terminator:    term,
 	}
 
+	// Build the mutable directory tree from the parsed entries. It backs
+	// the file APIs (ReadFile/AddFile/RemoveFile) and, once modified,
+	// becomes the source of truth for Save.
+	root := tree.NewRoot()
+	for _, entry := range filesystemEntries {
+		if entry.IsDir {
+			node, err := root.AddDirectory(entry.FullPath)
+			if err != nil {
+				return nil, fmt.Errorf("failed to build directory tree: %w", err)
+			}
+			node.SetMode(entry.Mode)
+			node.SetModTime(entry.ModTime)
+		} else {
+			_, err := root.AddExistingFile(entry.FullPath, isoReader, entry.Location, entry.Size, entry.Mode, entry.ModTime)
+			if err != nil {
+				return nil, fmt.Errorf("failed to build directory tree: %w", err)
+			}
+		}
+	}
+
 	iso := &ISO9660{
 		isoReader:           isoReader,
 		openOptions:         openOptions, //TODO: Work on making composite options that limit users ability to create based on context but have a single set behind the scenes
@@ -149,6 +171,7 @@ func Open(isoReader io.ReaderAt, opts ...option.OpenOption) (*ISO9660, error) {
 		volumeDescriptorSet: volumeDescSet,
 		pathTables:          tables,
 		filesystemEntries:   filesystemEntries,
+		root:                root,
 		elTorito:            et,
 		logger:              openOptions.Logger,
 		isPacked:            true,
@@ -157,110 +180,81 @@ func Open(isoReader io.ReaderAt, opts ...option.OpenOption) (*ISO9660, error) {
 	return iso, nil
 }
 
+// Create builds a new, empty ISO9660 filesystem in memory. Files and
+// directories are added with AddFile, AddDirectory, and AddLocalDirectory;
+// Save then lays out and writes the complete image.
 func Create(name string, opts ...option.CreateOption) (*ISO9660, error) {
 	// Set default create options
 	createOptions := &option.CreateOptions{
 		Preparer: fmt.Sprintf("iso-kit %s %s (%s) %s", version.Version(), version.Revision(), version.Branch(), version.Date()),
+		Logger:   logging.DefaultLogger(),
 	}
 
 	for _, opt := range opts {
 		opt(createOptions)
 	}
+	if createOptions.Logger == nil {
+		createOptions.Logger = logging.DefaultLogger()
+	}
 
-	//// Create a root directory record
-	//rootDir := &directory.DirectoryRecord{
-	//	FileIdentifier:                "\x00",
-	//	LengthOfDirectoryRecord:       0,
-	//	ExtendedAttributeRecordLength: 0,
-	//	LocationOfExtent:              0, // Updated when writing directory structures
-	//	DataLength:                    0,
-	//	RecordingDateAndTime:          time.Now(),
-	//	FileFlags:                     directory.FileFlags{Directory: true},
-	//	VolumeSequenceNumber:          1, // Volume sequence should be set
-	//}
+	now := time.Now()
+	root := tree.NewRoot()
 
-	//// 1: Create system area (First 16 sectors reserved, boot record might go here)
-	//sa := systemarea.SystemArea{}
-	//
-	//// 2: Create volume descriptor set
-	//pvd := descriptor.PrimaryVolumeDescriptor{
-	//	VolumeDescriptorHeader: descriptor.VolumeDescriptorHeader{
-	//		VolumeDescriptorType:    descriptor.TYPE_PRIMARY_DESCRIPTOR,
-	//		StandardIdentifier:      consts.ISO9660_STD_IDENTIFIER,
-	//		VolumeDescriptorVersion: consts.ISO9660_VOLUME_DESC_VERSION,
-	//	},
-	//	PrimaryVolumeDescriptorBody: descriptor.PrimaryVolumeDescriptorBody{
-	//		SystemIdentifier:              "",
-	//		VolumeIdentifier:              name,
-	//		VolumeSpaceSize:               0, // Set later
-	//		VolumeSetSize:                 1, // Single volume
-	//		VolumeSequenceNumber:          1,
-	//		LogicalBlockSize:              consts.ISO9660_SECTOR_SIZE,
-	//		RootDirectoryRecord:           rootDir,
-	//		VolumeSetIdentifier:           "",
-	//		PublisherIdentifier:           "",
-	//		DataPreparerIdentifier:        createOptions.Preparer,
-	//		ApplicationIdentifier:         "",
-	//		VolumeCreationDateAndTime:     time.Now(),
-	//		VolumeModificationDateAndTime: time.Now(),
-	//		VolumeExpirationDateAndTime:   time.Now(),
-	//		VolumeEffectiveDateAndTime:    time.Now(),
-	//		FileStructureVersion:          1,
-	//	},
-	//}
-	//
-	//// 2.2: Create supplementary volume descriptor (if Joliet is enabled)
-	//var svds []*descriptor.SupplementaryVolumeDescriptor
-	//if createOptions.JolietEnabled {
-	//	svd := descriptor.SupplementaryVolumeDescriptor{
-	//		VolumeDescriptorHeader: descriptor.VolumeDescriptorHeader{
-	//			VolumeDescriptorType:    descriptor.TYPE_SUPPLEMENTARY_DESCRIPTOR,
-	//			StandardIdentifier:      consts.ISO9660_STD_IDENTIFIER,
-	//			VolumeDescriptorVersion: consts.ISO9660_VOLUME_DESC_VERSION,
-	//		},
-	//		SupplementaryVolumeDescriptorBody: descriptor.SupplementaryVolumeDescriptorBody{
-	//			VolumeFlags:                   0,
-	//			SystemIdentifier:              "",
-	//			VolumeIdentifier:              name,
-	//			VolumeSpaceSize:               [8]byte{}, // Needs to be set later
-	//			RootDirectoryRecord:           rootDir,
-	//			VolumeSetIdentifier:           "",
-	//			PublisherIdentifier:           "",
-	//			DataPreparerIdentifier:        createOptions.Preparer,
-	//			ApplicationIdentifier:         "",
-	//			VolumeCreationDateAndTime:     time.Now(),
-	//			VolumeModificationDateAndTime: time.Now(),
-	//			VolumeExpirationDateAndTime:   time.Now(),
-	//			VolumeEffectiveDateAndTime:    time.Now(),
-	//			FileStructureVersion:          1,
-	//		},
-	//	}
-	//	// Copy the Joliet escape sequence (%/@ for Level 3)
-	//	copy(svd.SupplementaryVolumeDescriptorBody.EscapeSequences[:], []byte(consts.JOLIET_LEVEL_3_ESCAPE))
-	//	svds = append(svds, &svd)
-	//}
+	// The root directory record is a placeholder here; Pack replaces it
+	// with one carrying the assigned extent location and size.
+	rootRecord := &directory.DirectoryRecord{
+		LocationOfExtent:       0,
+		DataLength:             0,
+		RecordingDateAndTime:   now,
+		FileFlags:              directory.FileFlags{Directory: true},
+		VolumeSequenceNumber:   1,
+		LengthOfFileIdentifier: 1,
+		FileIdentifier:         "\x00",
+	}
 
-	// 2.3: Create volume partition descriptor(s) (not used often in basic ISO9660)
-	//var pvds []*descriptor.VolumePartitionDescriptor
-	//
-	//// 2.4: Create boot record (only needed for bootable ISOs)
-	//br := descriptor.BootRecordDescriptor{}
+	pvd := &descriptor.PrimaryVolumeDescriptor{
+		VolumeDescriptorHeader: descriptor.VolumeDescriptorHeader{
+			VolumeDescriptorType:    descriptor.TYPE_PRIMARY_DESCRIPTOR,
+			StandardIdentifier:      consts.ISO9660_STD_IDENTIFIER,
+			VolumeDescriptorVersion: consts.ISO9660_VOLUME_DESC_VERSION,
+		},
+		PrimaryVolumeDescriptorBody: descriptor.PrimaryVolumeDescriptorBody{
+			VolumeIdentifier:              name,
+			VolumeSetSize:                 1,
+			VolumeSequenceNumber:          1,
+			LogicalBlockSize:              consts.ISO9660_SECTOR_SIZE,
+			RootDirectoryRecord:           rootRecord,
+			DataPreparerIdentifier:        createOptions.Preparer,
+			VolumeCreationDateAndTime:     now,
+			VolumeModificationDateAndTime: now,
+			FileStructureVersion:          1,
+			Logger:                        createOptions.Logger,
+		},
+	}
 
-	// 3: Initialize path tables (Will need to be generated)
-	// Placeholder for path table setup
-
-	// 4: Create directory records (Root directory will be updated dynamically)
-	// Placeholder for directory handling
-
-	// Build ISO structure
 	iso := &ISO9660{
-		//createOptions: createOptions,
-		//systemArea:    sa,
-		//bootRecord:    &br,
-		//pvd:           &pvd,
-		//svds:          svds,
-		//partitionvds:  pvds,
-		//logger:        createOptions.Logger,
+		createOptions: createOptions,
+		systemArea: systemarea.SystemArea{
+			ObjectSize: consts.ISO9660_SECTOR_SIZE * consts.ISO9660_SYSTEM_AREA_SECTORS,
+		},
+		volumeDescriptorSet: &descriptor.VolumeDescriptorSet{
+			Primary:    pvd,
+			Terminator: descriptor.NewVolumeDescriptorSetTerminator(),
+		},
+		root:     root,
+		logger:   createOptions.Logger,
+		isDirty:  true,
+		isPacked: false,
+	}
+
+	if createOptions.JolietEnabled {
+		iso.logger.Info("WARNING: Joliet output is not yet supported; the image will be written without a supplementary volume descriptor")
+	}
+
+	if createOptions.RootDir != "" {
+		if err := iso.AddLocalDirectory(createOptions.RootDir, "/"); err != nil {
+			return nil, err
+		}
 	}
 
 	return iso, nil
@@ -284,10 +278,18 @@ type ISO9660 struct {
 	elTorito *boot.ElTorito
 	// FileSystemEntries
 	filesystemEntries []*filesystem.FileSystemEntry
+	// Mutable directory tree; the source of truth for filesystem state
+	root *tree.Node
+	// Sector assignments produced by Pack
+	layout *packLayout
 	// Logger
 	logger *logging.Logger
 	// isPacked represents if the ISO9660 filesystem is packed and ready to write to disk
 	isPacked bool
+	// isDirty is set when the tree has been modified since Open/Create,
+	// meaning Save must rebuild the image layout rather than re-serialize
+	// parsed structures at their original offsets
+	isDirty bool
 }
 
 func (iso *ISO9660) preferJoliet() bool {
@@ -532,8 +534,52 @@ func (iso *ISO9660) ListBootEntries() ([]*filesystem.FileSystemEntry, error) {
 	return iso.elTorito.BuildBootImageEntries()
 }
 
+// refreshEntriesFromTree rebuilds the flat entry list from the mutable
+// tree when the cached parse-time list has been invalidated by a
+// modification. Entries built this way have Location 0 with a reader whose
+// offset 0 is the start of the file, and carry no directory record.
+func (iso *ISO9660) refreshEntriesFromTree() error {
+	if iso.filesystemEntries != nil || iso.root == nil {
+		return nil
+	}
+	entries := make([]*filesystem.FileSystemEntry, 0)
+	err := iso.root.Walk(func(node *tree.Node) error {
+		var reader io.ReaderAt
+		if !node.IsDir() {
+			r, err := node.ContentReaderAt(consts.ISO9660_SECTOR_SIZE)
+			if err != nil {
+				return err
+			}
+			reader = r
+		}
+		entries = append(entries, filesystem.NewFileSystemEntry(
+			node.Name(),
+			node.FullPath(),
+			node.IsDir(),
+			node.Size(),
+			0,
+			nil,
+			nil,
+			node.Mode(),
+			node.ModTime(),
+			node.ModTime(),
+			nil,
+			reader,
+		))
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	iso.filesystemEntries = entries
+	return nil
+}
+
 // ListFiles returns a list of all files in the ISO9660 filesystem.
 func (iso *ISO9660) ListFiles() ([]*filesystem.FileSystemEntry, error) {
+	if err := iso.refreshEntriesFromTree(); err != nil {
+		return nil, err
+	}
 	files := make([]*filesystem.FileSystemEntry, 0)
 	for _, entry := range iso.filesystemEntries {
 		if !entry.IsDir {
@@ -546,6 +592,9 @@ func (iso *ISO9660) ListFiles() ([]*filesystem.FileSystemEntry, error) {
 
 // ListDirectories returns a list of all directories in the ISO9660 filesystem.
 func (iso *ISO9660) ListDirectories() ([]*filesystem.FileSystemEntry, error) {
+	if err := iso.refreshEntriesFromTree(); err != nil {
+		return nil, err
+	}
 	dirs := make([]*filesystem.FileSystemEntry, 0)
 	for _, entry := range iso.filesystemEntries {
 		if entry.IsDir {
@@ -556,19 +605,149 @@ func (iso *ISO9660) ListDirectories() ([]*filesystem.FileSystemEntry, error) {
 	return dirs, nil
 }
 
+// ReadFile returns the content of the file at the given path. The path is
+// slash-separated relative to the image root; an ISO 9660 version suffix
+// (";1") on the final component is optional.
 func (iso *ISO9660) ReadFile(path string) ([]byte, error) {
-	//TODO implement me
-	panic("implement me")
+	if iso.root == nil {
+		return nil, errors.New("no filesystem is loaded")
+	}
+	node := iso.root.Lookup(path)
+	if node == nil {
+		return nil, fmt.Errorf("file not found: %s", path)
+	}
+	if node.IsDir() {
+		return nil, fmt.Errorf("path is a directory: %s", path)
+	}
+	return node.ReadData(consts.ISO9660_SECTOR_SIZE)
 }
 
+// AddFile adds a file with the given content at the given path, creating
+// parent directories as needed. An existing file at the path is replaced.
 func (iso *ISO9660) AddFile(path string, data []byte) error {
-	//TODO implement me
-	panic("implement me")
+	if iso.root == nil {
+		return errors.New("no filesystem is loaded")
+	}
+	if _, err := iso.root.AddFile(path, data); err != nil {
+		return err
+	}
+	iso.markDirty()
+	return nil
 }
 
+// AddDirectory creates an empty directory at the given path, creating
+// parent directories as needed.
+func (iso *ISO9660) AddDirectory(path string) error {
+	if iso.root == nil {
+		return errors.New("no filesystem is loaded")
+	}
+	if _, err := iso.root.AddDirectory(path); err != nil {
+		return err
+	}
+	iso.markDirty()
+	return nil
+}
+
+// AddLocalDirectory recursively imports a directory from the local
+// filesystem into the image at targetPath. File content is read into
+// memory at Save time via the pending-data mechanism; large trees are read
+// eagerly here, so callers importing very large directories should expect
+// proportional memory use until streaming import support lands.
+func (iso *ISO9660) AddLocalDirectory(sourcePath, targetPath string) error {
+	if iso.root == nil {
+		return errors.New("no filesystem is loaded")
+	}
+	sourcePath = filepath.Clean(sourcePath)
+	err := filepath.Walk(sourcePath, func(path string, fi os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(sourcePath, path)
+		if err != nil {
+			return err
+		}
+		isoPath := targetPath
+		if rel != "." {
+			isoPath = strings.TrimSuffix(targetPath, "/") + "/" + filepath.ToSlash(rel)
+		}
+		if fi.IsDir() {
+			node, err := iso.root.AddDirectory(isoPath)
+			if err != nil {
+				return err
+			}
+			node.SetMode(fi.Mode().Perm())
+			node.SetModTime(fi.ModTime())
+			return nil
+		}
+		if !fi.Mode().IsRegular() {
+			iso.logger.Info("Skipping non-regular file", "path", path)
+			return nil
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("failed to read %s: %w", path, err)
+		}
+		node, err := iso.root.AddFile(isoPath, data)
+		if err != nil {
+			return err
+		}
+		node.SetMode(fi.Mode().Perm())
+		node.SetModTime(fi.ModTime())
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	iso.markDirty()
+	return nil
+}
+
+// RemoveFile removes the file at the given path. Removing a directory is
+// an error; use RemoveDirectory instead.
 func (iso *ISO9660) RemoveFile(path string) error {
-	//TODO implement me
-	panic("implement me")
+	if iso.root == nil {
+		return errors.New("no filesystem is loaded")
+	}
+	node := iso.root.Lookup(path)
+	if node == nil {
+		return fmt.Errorf("file not found: %s", path)
+	}
+	if node.IsDir() {
+		return fmt.Errorf("path is a directory (use RemoveDirectory): %s", path)
+	}
+	if err := iso.root.Remove(path); err != nil {
+		return err
+	}
+	iso.markDirty()
+	return nil
+}
+
+// RemoveDirectory removes the directory at the given path along with its
+// entire subtree.
+func (iso *ISO9660) RemoveDirectory(path string) error {
+	if iso.root == nil {
+		return errors.New("no filesystem is loaded")
+	}
+	node := iso.root.Lookup(path)
+	if node == nil {
+		return fmt.Errorf("directory not found: %s", path)
+	}
+	if !node.IsDir() {
+		return fmt.Errorf("path is a file (use RemoveFile): %s", path)
+	}
+	if err := iso.root.Remove(path); err != nil {
+		return err
+	}
+	iso.markDirty()
+	return nil
+}
+
+// markDirty records that the tree has diverged from the parsed image, so
+// Save must rebuild the layout, and invalidates the flat entry cache.
+func (iso *ISO9660) markDirty() {
+	iso.isDirty = true
+	iso.isPacked = false
+	iso.filesystemEntries = nil
 }
 
 // CreateDirectories creates all directories from the ISO in the specified path.
@@ -748,14 +927,17 @@ func (iso *ISO9660) GetObjects() []info.ImageObject {
 	return objects
 }
 
+// Save writes the complete image to the writer. An image opened from disk
+// and never modified is re-serialized at its original offsets; a created
+// or modified image is packed (sector layout assigned) and rebuilt from
+// the directory tree.
 func (iso *ISO9660) Save(writer io.WriterAt) error {
-	// Ensure the ISO is packed and all objects have been assigned locations
-	if !iso.isPacked {
-		// TODO: Make packing automatic
-		return errors.New("iso is not packed, cannot save")
+	if iso.isDirty || iso.isoReader == nil {
+		return iso.saveRebuild(writer)
 	}
 
-	// Get all objects
+	// Pristine passthrough: re-serialize parsed structures at their
+	// original byte offsets.
 	objects := iso.GetObjects()
 
 	// Sort objects by offset before writing
@@ -778,6 +960,122 @@ func (iso *ISO9660) Save(writer io.WriterAt) error {
 		}
 	}
 
+	return nil
+}
+
+// saveRebuild lays out and writes a complete image from the directory
+// tree: system area, volume descriptors, path tables, directory extents,
+// and file extents. Every allocated sector is written in full, so the
+// resulting image is exactly VolumeSpaceSize sectors long.
+func (iso *ISO9660) saveRebuild(writer io.WriterAt) error {
+	if iso.root == nil {
+		return errors.New("no filesystem is loaded")
+	}
+
+	if iso.volumeDescriptorSet.Boot != nil || iso.elTorito != nil {
+		iso.logger.Info("WARNING: El Torito boot structures are not yet supported in rebuilt images; the output will not be bootable")
+	}
+	if len(iso.volumeDescriptorSet.Supplementary) > 0 {
+		iso.logger.Info("WARNING: Joliet output is not yet supported; the supplementary volume descriptor is dropped from the rebuilt image")
+	}
+
+	if err := iso.Pack(); err != nil {
+		return fmt.Errorf("failed to pack image: %w", err)
+	}
+
+	// 1. System area (sectors 0-15).
+	if _, err := writer.WriteAt(iso.systemArea.Contents[:], 0); err != nil {
+		return fmt.Errorf("failed to write system area: %w", err)
+	}
+
+	// 2. Primary volume descriptor.
+	pvdBytes, err := iso.volumeDescriptorSet.Primary.Marshal()
+	if err != nil {
+		return fmt.Errorf("failed to marshal primary volume descriptor: %w", err)
+	}
+	if _, err := writer.WriteAt(pvdBytes, int64(iso.layout.pvdSector)*consts.ISO9660_SECTOR_SIZE); err != nil {
+		return fmt.Errorf("failed to write primary volume descriptor: %w", err)
+	}
+
+	// 3. Volume descriptor set terminator.
+	term := iso.volumeDescriptorSet.Terminator
+	if term == nil {
+		term = descriptor.NewVolumeDescriptorSetTerminator()
+		iso.volumeDescriptorSet.Terminator = term
+	}
+	term.ObjectLocation = int64(iso.layout.terminatorSector) * consts.ISO9660_SECTOR_SIZE
+	term.VolumeDescriptorSetTerminatorBody.ObjectSize = consts.ISO9660_SECTOR_SIZE
+	termBytes, err := term.Marshal()
+	if err != nil {
+		return fmt.Errorf("failed to marshal volume descriptor set terminator: %w", err)
+	}
+	if _, err := writer.WriteAt(termBytes, term.ObjectLocation); err != nil {
+		return fmt.Errorf("failed to write volume descriptor set terminator: %w", err)
+	}
+
+	// 4. Path tables (L then M), zero-padded to whole sectors.
+	ptL, ptM, err := iso.buildPathTables()
+	if err != nil {
+		return err
+	}
+	for _, pt := range []*pathtable.PathTable{ptL, ptM} {
+		data, err := pt.Marshal()
+		if err != nil {
+			return fmt.Errorf("failed to marshal path table: %w", err)
+		}
+		padded := make([]byte, sectorsFor(uint32(len(data)))*consts.ISO9660_SECTOR_SIZE)
+		copy(padded, data)
+		if _, err := writer.WriteAt(padded, pt.Offset()); err != nil {
+			return fmt.Errorf("failed to write path table: %w", err)
+		}
+	}
+	iso.pathTables = []*pathtable.PathTable{ptL, ptM}
+
+	// 5. Directory extents in breadth-first order.
+	for _, dir := range iso.layout.dirs {
+		data, err := marshalDirectoryExtent(dir)
+		if err != nil {
+			return err
+		}
+		if _, err := writer.WriteAt(data, int64(dir.PackedLocation)*consts.ISO9660_SECTOR_SIZE); err != nil {
+			return fmt.Errorf("failed to write directory extent for %q: %w", dir.FullPath(), err)
+		}
+	}
+
+	// 6. File extents, each zero-padded to whole sectors.
+	for _, file := range iso.layout.files {
+		if err := iso.writeFileExtent(writer, file); err != nil {
+			return err
+		}
+	}
+
+	iso.isDirty = false
+	return nil
+}
+
+// writeFileExtent streams a file's content to its packed location and
+// zero-fills the remainder of its final sector.
+func (iso *ISO9660) writeFileExtent(writer io.WriterAt, node *tree.Node) error {
+	if node.Size() == 0 {
+		return nil
+	}
+	content, err := node.Content(consts.ISO9660_SECTOR_SIZE)
+	if err != nil {
+		return err
+	}
+	targetOffset := int64(node.PackedLocation) * consts.ISO9660_SECTOR_SIZE
+	written, err := io.Copy(io.NewOffsetWriter(writer, targetOffset), content)
+	if err != nil {
+		return fmt.Errorf("failed to write content of %q: %w", node.FullPath(), err)
+	}
+	if written != int64(node.Size()) {
+		return fmt.Errorf("short write for %q: wrote %d of %d bytes", node.FullPath(), written, node.Size())
+	}
+	if pad := int64(sectorsFor(node.Size()))*consts.ISO9660_SECTOR_SIZE - written; pad > 0 {
+		if _, err := writer.WriteAt(make([]byte, pad), targetOffset+written); err != nil {
+			return fmt.Errorf("failed to pad extent of %q: %w", node.FullPath(), err)
+		}
+	}
 	return nil
 }
 

--- a/pkg/iso9660/pack.go
+++ b/pkg/iso9660/pack.go
@@ -1,0 +1,281 @@
+package iso9660
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/bgrewell/iso-kit/pkg/consts"
+	"github.com/bgrewell/iso-kit/pkg/iso9660/directory"
+	"github.com/bgrewell/iso-kit/pkg/iso9660/pathtable"
+	"github.com/bgrewell/iso-kit/pkg/iso9660/tree"
+)
+
+const (
+	// Fixed portion of a directory record preceding the file identifier:
+	// length(1) + xattr(1) + extent(8) + data length(8) + timestamp(7) +
+	// flags(1) + unit size(1) + gap size(1) + volume sequence(4) + id length(1).
+	directoryRecordFixedSize = 33
+)
+
+// directoryRecordLength returns the on-disk length of a directory record
+// for an identifier of the given byte length. A pad byte follows the
+// identifier when its length is even, keeping the record length even.
+func directoryRecordLength(identifierLen int) int {
+	length := directoryRecordFixedSize + identifierLen
+	if identifierLen%2 == 0 {
+		length++
+	}
+	return length
+}
+
+// isoFileIdentifier returns the on-disk identifier for a node: files carry
+// the ISO 9660 ";1" version suffix, directories do not.
+func isoFileIdentifier(node *tree.Node) string {
+	if node.IsDir() {
+		return node.Name()
+	}
+	return node.Name() + ";1"
+}
+
+// sectorsFor returns the number of whole sectors needed for size bytes.
+func sectorsFor(size uint32) uint32 {
+	return (size + consts.ISO9660_SECTOR_SIZE - 1) / consts.ISO9660_SECTOR_SIZE
+}
+
+// directoryExtentSize computes the size in bytes of a directory's extent:
+// the "." and ".." records plus one record per child, laid out so no record
+// crosses a sector boundary, rounded up to a whole sector.
+func directoryExtentSize(dir *tree.Node) uint32 {
+	offset := directoryRecordLength(1) * 2 // "." and ".."
+	for _, child := range dir.Children() {
+		recLen := directoryRecordLength(len(isoFileIdentifier(child)))
+		if offset%consts.ISO9660_SECTOR_SIZE+recLen > consts.ISO9660_SECTOR_SIZE {
+			offset = (offset/consts.ISO9660_SECTOR_SIZE + 1) * consts.ISO9660_SECTOR_SIZE
+		}
+		offset += recLen
+	}
+	return sectorsFor(uint32(offset)) * consts.ISO9660_SECTOR_SIZE
+}
+
+// pathTableSize computes the byte size of a path table over the given
+// breadth-first directory list. Each record is 8 bytes plus the identifier,
+// plus a pad byte when the identifier length is odd. Both the L and M
+// tables have the same size.
+func pathTableSize(dirs []*tree.Node) uint32 {
+	var size uint32
+	for _, dir := range dirs {
+		idLen := 1 // root identifier is a single 0x00 byte
+		if !dir.IsRoot() {
+			idLen = len(dir.Name())
+		}
+		recLen := 8 + idLen
+		if idLen%2 != 0 {
+			recLen++
+		}
+		size += uint32(recLen)
+	}
+	return size
+}
+
+// packLayout holds the sector assignments produced by Pack.
+type packLayout struct {
+	pvdSector        uint32
+	terminatorSector uint32
+	pathTableLSector uint32
+	pathTableMSector uint32
+	pathTableSize    uint32
+	totalSectors     uint32
+	// dirs is the breadth-first directory list; index+1 is each
+	// directory's path table number.
+	dirs []*tree.Node
+	// files is every file node in tree walk order.
+	files []*tree.Node
+}
+
+// Pack assigns a sector location to every structure in the image: volume
+// descriptors, path tables, directory extents, and file extents. It updates
+// the PVD's size and location cross-references so a subsequent Save writes
+// a consistent image. The layout is:
+//
+//	sectors 0-15   system area
+//	sector  16     primary volume descriptor
+//	sector  17     volume descriptor set terminator
+//	next           L path table, then M path table
+//	next           directory extents in breadth-first order (root first)
+//	next           file extents
+//
+// Note: supplementary (Joliet) descriptors are not yet written; a source
+// image's SVDs are dropped from the rebuilt output.
+func (iso *ISO9660) Pack() error {
+	if iso.root == nil {
+		return fmt.Errorf("no directory tree to pack")
+	}
+	pvd := iso.volumeDescriptorSet.Primary
+	if pvd == nil {
+		return fmt.Errorf("primary volume descriptor is missing")
+	}
+
+	layout := &packLayout{
+		pvdSector:        consts.ISO9660_SYSTEM_AREA_SECTORS,
+		terminatorSector: consts.ISO9660_SYSTEM_AREA_SECTORS + 1,
+		dirs:             iso.root.Directories(),
+	}
+
+	// Directory extent sizes are independent of location, so they can be
+	// computed before sectors are assigned.
+	for _, dir := range layout.dirs {
+		dir.PackedSize = directoryExtentSize(dir)
+	}
+	layout.pathTableSize = pathTableSize(layout.dirs)
+
+	next := layout.terminatorSector + 1
+	layout.pathTableLSector = next
+	next += sectorsFor(layout.pathTableSize)
+	layout.pathTableMSector = next
+	next += sectorsFor(layout.pathTableSize)
+
+	for _, dir := range layout.dirs {
+		dir.PackedLocation = next
+		next += sectorsFor(dir.PackedSize)
+	}
+
+	err := iso.root.Walk(func(node *tree.Node) error {
+		if node.IsDir() {
+			return nil
+		}
+		node.PackedLocation = next
+		node.PackedSize = node.Size()
+		next += sectorsFor(node.Size())
+		layout.files = append(layout.files, node)
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	layout.totalSectors = next
+
+	// Update the PVD cross-references.
+	pvd.VolumeSpaceSize = layout.totalSectors
+	pvd.PrimaryVolumeDescriptorBody.PathTableSize = layout.pathTableSize
+	pvd.LocationOfTypeLPathTable = layout.pathTableLSector
+	pvd.LocationOfOptionalTypeLPathTable = 0
+	pvd.LocationOfTypeMPathTable = layout.pathTableMSector
+	pvd.LocationOfOptionalTypeMPathTable = 0
+	pvd.ObjectLocation = int64(layout.pvdSector) * consts.ISO9660_SECTOR_SIZE
+	pvd.ObjectSize = consts.ISO9660_SECTOR_SIZE
+	if pvd.LogicalBlockSize == 0 {
+		pvd.LogicalBlockSize = consts.ISO9660_SECTOR_SIZE
+	}
+	if pvd.VolumeSetSize == 0 {
+		pvd.VolumeSetSize = 1
+	}
+	if pvd.VolumeSequenceNumber == 0 {
+		pvd.VolumeSequenceNumber = 1
+	}
+
+	// The root directory record embedded in the PVD points at the root
+	// extent.
+	pvd.RootDirectoryRecord = buildDirectoryRecord(iso.root, "\x00", iso.root)
+
+	iso.layout = layout
+	iso.isPacked = true
+	return nil
+}
+
+// recordingTime returns a timestamp valid for the 7-byte recording
+// date/time format, substituting the current time for zero values.
+func recordingTime(t time.Time) time.Time {
+	if t.IsZero() || t.Year() < 1900 || t.Year() > 2155 {
+		return time.Now()
+	}
+	return t
+}
+
+// buildDirectoryRecord constructs the on-disk directory record describing
+// target, using the given identifier. The record's extent fields come from
+// target's packed location and size, so Pack must run first.
+func buildDirectoryRecord(target *tree.Node, identifier string, self *tree.Node) *directory.DirectoryRecord {
+	return &directory.DirectoryRecord{
+		LocationOfExtent:       target.PackedLocation,
+		DataLength:             target.PackedSize,
+		RecordingDateAndTime:   recordingTime(self.ModTime()),
+		FileFlags:              directory.FileFlags{Directory: target.IsDir()},
+		VolumeSequenceNumber:   1,
+		LengthOfFileIdentifier: uint8(len(identifier)),
+		FileIdentifier:         identifier,
+	}
+}
+
+// marshalDirectoryExtent serializes a directory's extent: the "." and ".."
+// records followed by one record per child, zero-padding whenever a record
+// would cross a sector boundary. The result is exactly dir.PackedSize bytes.
+func marshalDirectoryExtent(dir *tree.Node) ([]byte, error) {
+	buf := make([]byte, dir.PackedSize)
+	offset := 0
+
+	parent := dir.Parent()
+	if parent == nil {
+		parent = dir // the root's ".." points at itself
+	}
+
+	records := []*directory.DirectoryRecord{
+		buildDirectoryRecord(dir, "\x00", dir),
+		buildDirectoryRecord(parent, "\x01", dir),
+	}
+	for _, child := range dir.Children() {
+		records = append(records, buildDirectoryRecord(child, isoFileIdentifier(child), child))
+	}
+
+	for _, rec := range records {
+		data, err := rec.Marshal()
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal directory record %q in %q: %w",
+				rec.FileIdentifier, dir.FullPath(), err)
+		}
+		if offset%consts.ISO9660_SECTOR_SIZE+len(data) > consts.ISO9660_SECTOR_SIZE {
+			offset = (offset/consts.ISO9660_SECTOR_SIZE + 1) * consts.ISO9660_SECTOR_SIZE
+		}
+		if offset+len(data) > len(buf) {
+			return nil, fmt.Errorf("directory extent overflow in %q: computed size %d too small",
+				dir.FullPath(), dir.PackedSize)
+		}
+		copy(buf[offset:], data)
+		offset += len(data)
+	}
+
+	return buf, nil
+}
+
+// buildPathTables produces the L (little-endian) and M (big-endian) path
+// tables from the packed directory list. Directory numbering follows the
+// breadth-first order of layout.dirs, so a directory's path table number is
+// its index plus one.
+func (iso *ISO9660) buildPathTables() (*pathtable.PathTable, *pathtable.PathTable, error) {
+	if iso.layout == nil {
+		return nil, nil, fmt.Errorf("image is not packed")
+	}
+
+	dirNumber := make(map[*tree.Node]uint16, len(iso.layout.dirs))
+	for i, dir := range iso.layout.dirs {
+		dirNumber[dir] = uint16(i + 1)
+	}
+
+	ptL := pathtable.NewEmptyPathTable("Primary", true)
+	ptM := pathtable.NewEmptyPathTable("Primary", false)
+	for _, dir := range iso.layout.dirs {
+		identifier := "\x00"
+		parentNumber := uint16(1)
+		if !dir.IsRoot() {
+			identifier = dir.Name()
+			parentNumber = dirNumber[dir.Parent()]
+		}
+		ptL.AddRecord(identifier, dir.PackedLocation, parentNumber)
+		ptM.AddRecord(identifier, dir.PackedLocation, parentNumber)
+	}
+
+	ptL.SetLocation(iso.layout.pathTableLSector, iso.layout.pathTableSize)
+	ptM.SetLocation(iso.layout.pathTableMSector, iso.layout.pathTableSize)
+
+	return ptL, ptM, nil
+}

--- a/pkg/iso9660/pathtable/record.go
+++ b/pkg/iso9660/pathtable/record.go
@@ -43,6 +43,36 @@ func NewPathTable(reader io.ReaderAt, location uint32, size int, source string, 
 	return pt, nil
 }
 
+// NewEmptyPathTable creates an empty path table for building an image in
+// memory. Records are added with AddRecord; the table's byte location is
+// assigned later by the layout engine via SetLocation.
+func NewEmptyPathTable(source string, littleEndian bool) *PathTable {
+	return &PathTable{
+		source:       source,
+		littleEndian: littleEndian,
+	}
+}
+
+// AddRecord appends a path table record. Records must be added in the
+// order required by ECMA-119: breadth-first, parents before children,
+// siblings ordered by directory identifier.
+func (pt *PathTable) AddRecord(directoryIdentifier string, locationOfExtent uint32, parentDirectoryNumber uint16) {
+	pt.Records = append(pt.Records, &PathTableRecord{
+		LengthOfDirectoryIdentifier: uint8(len(directoryIdentifier)),
+		LocationOfExtent:            locationOfExtent,
+		ParentDirectoryNumber:       parentDirectoryNumber,
+		DirectoryIdentifier:         directoryIdentifier,
+		littleEndian:                pt.littleEndian,
+	})
+}
+
+// SetLocation assigns the table's on-image sector location and its size in
+// bytes, used by the layout engine after sector assignment.
+func (pt *PathTable) SetLocation(sector uint32, size uint32) {
+	pt.ObjectLocation = int64(sector)
+	pt.ObjectSize = size
+}
+
 // PathTable represents a full path table, containing multiple records.
 type PathTable struct {
 	Records      []*PathTableRecord

--- a/pkg/iso9660/tree/tree.go
+++ b/pkg/iso9660/tree/tree.go
@@ -1,0 +1,371 @@
+// Package tree provides a mutable in-memory representation of an ISO 9660
+// directory hierarchy. It is the single source of truth for filesystem state
+// between Open/Create and Save: entries parsed from an existing image and
+// entries added in memory coexist in the same structure, and the layout
+// engine walks it to assign sector locations before writing.
+package tree
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strings"
+	"time"
+)
+
+// Node is a single file or directory in the tree.
+//
+// File content comes from exactly one of two sources: Data (in-memory,
+// pending) or a backing io.ReaderAt plus sector Location (content that
+// already lives in an opened image). Directories have neither.
+type Node struct {
+	name     string
+	isDir    bool
+	parent   *Node
+	children map[string]*Node
+
+	// In-memory content for files added or replaced since Open/Create.
+	data []byte
+	// Backing reader for content already recorded in an existing image.
+	reader io.ReaderAt
+	// Sector location of the extent in the backing reader.
+	location uint32
+	// Content size in bytes. For reader-backed files this is the extent
+	// data length; for in-memory files it mirrors len(data).
+	size uint32
+
+	mode    os.FileMode
+	modTime time.Time
+
+	// PackedLocation and PackedSize are assigned by the layout engine
+	// before writing. PackedSize for a directory is the extent size in
+	// bytes (a multiple of the sector size); for a file it equals size.
+	PackedLocation uint32
+	PackedSize     uint32
+}
+
+// NewRoot returns an empty root directory node.
+func NewRoot() *Node {
+	return &Node{
+		isDir:    true,
+		children: map[string]*Node{},
+		mode:     0o755,
+		modTime:  time.Now(),
+	}
+}
+
+// Name returns the node's name. The root has an empty name.
+func (n *Node) Name() string { return n.name }
+
+// IsDir reports whether the node is a directory.
+func (n *Node) IsDir() bool { return n.isDir }
+
+// IsRoot reports whether the node is the tree root.
+func (n *Node) IsRoot() bool { return n.parent == nil }
+
+// Parent returns the parent node, or nil for the root.
+func (n *Node) Parent() *Node { return n.parent }
+
+// Size returns the content size in bytes. Directories return 0.
+func (n *Node) Size() uint32 { return n.size }
+
+// Mode returns the POSIX file mode.
+func (n *Node) Mode() os.FileMode { return n.mode }
+
+// ModTime returns the modification time.
+func (n *Node) ModTime() time.Time { return n.modTime }
+
+// SetMode sets the POSIX file mode.
+func (n *Node) SetMode(mode os.FileMode) { n.mode = mode }
+
+// SetModTime sets the modification time.
+func (n *Node) SetModTime(t time.Time) { n.modTime = t }
+
+// IsPending reports whether the node's content lives in memory rather than
+// in a backing image.
+func (n *Node) IsPending() bool { return n.data != nil }
+
+// FullPath returns the slash-separated path from the root, e.g.
+// "dir/subdir/file.txt". The root returns "".
+func (n *Node) FullPath() string {
+	if n.parent == nil {
+		return ""
+	}
+	parts := []string{}
+	for cur := n; cur.parent != nil; cur = cur.parent {
+		parts = append(parts, cur.name)
+	}
+	for i, j := 0, len(parts)-1; i < j; i, j = i+1, j-1 {
+		parts[i], parts[j] = parts[j], parts[i]
+	}
+	return strings.Join(parts, "/")
+}
+
+// Children returns the node's children sorted by name. Sorting makes the
+// on-disk record order deterministic and satisfies the ECMA-119 requirement
+// that directory records be ordered by file identifier.
+func (n *Node) Children() []*Node {
+	out := make([]*Node, 0, len(n.children))
+	for _, c := range n.children {
+		out = append(out, c)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].name < out[j].name })
+	return out
+}
+
+// splitPath normalizes a slash-separated path into components. Leading and
+// trailing slashes are ignored, as are empty components.
+func splitPath(path string) []string {
+	var parts []string
+	for _, p := range strings.Split(path, "/") {
+		if p != "" && p != "." {
+			parts = append(parts, p)
+		}
+	}
+	return parts
+}
+
+// StripVersion removes an ISO 9660 file version suffix (";1", ";2", ...)
+// from a name if present.
+func StripVersion(name string) string {
+	if i := strings.LastIndexByte(name, ';'); i >= 0 {
+		version := name[i+1:]
+		if len(version) > 0 {
+			numeric := true
+			for _, r := range version {
+				if r < '0' || r > '9' {
+					numeric = false
+					break
+				}
+			}
+			if numeric {
+				return name[:i]
+			}
+		}
+	}
+	return name
+}
+
+// Lookup returns the node at the given path, or nil if not present. A file
+// version suffix on the final component is ignored, so "A.TXT;1" and
+// "A.TXT" resolve to the same node.
+func (n *Node) Lookup(path string) *Node {
+	cur := n
+	for _, part := range splitPath(path) {
+		if cur == nil || !cur.isDir {
+			return nil
+		}
+		next := cur.children[part]
+		if next == nil {
+			next = cur.children[StripVersion(part)]
+		}
+		cur = next
+	}
+	return cur
+}
+
+// mkdirs walks the path components, creating intermediate directories as
+// needed, and returns the final directory node. Returns an error if a
+// component exists as a file.
+func (n *Node) mkdirs(parts []string) (*Node, error) {
+	cur := n
+	for _, part := range parts {
+		child := cur.children[part]
+		if child == nil {
+			child = &Node{
+				name:     part,
+				isDir:    true,
+				parent:   cur,
+				children: map[string]*Node{},
+				mode:     0o755,
+				modTime:  time.Now(),
+			}
+			cur.children[part] = child
+		} else if !child.isDir {
+			return nil, fmt.Errorf("path component %q is a file, not a directory", child.FullPath())
+		}
+		cur = child
+	}
+	return cur, nil
+}
+
+// AddDirectory creates a directory at the given path, along with any
+// missing parents, and returns its node. Adding an existing directory is a
+// no-op that returns the existing node.
+func (n *Node) AddDirectory(path string) (*Node, error) {
+	parts := splitPath(path)
+	if len(parts) == 0 {
+		return n, nil
+	}
+	return n.mkdirs(parts)
+}
+
+// AddFile inserts a file with in-memory content at the given path, creating
+// parent directories as needed. An existing file at the path is replaced;
+// an existing directory is an error.
+func (n *Node) AddFile(path string, data []byte) (*Node, error) {
+	parts := splitPath(path)
+	if len(parts) == 0 {
+		return nil, fmt.Errorf("file path is empty")
+	}
+	name := StripVersion(parts[len(parts)-1])
+	if name == "" {
+		return nil, fmt.Errorf("file name is empty")
+	}
+	dir, err := n.mkdirs(parts[:len(parts)-1])
+	if err != nil {
+		return nil, err
+	}
+	if existing := dir.children[name]; existing != nil && existing.isDir {
+		return nil, fmt.Errorf("path %q is a directory", existing.FullPath())
+	}
+	node := &Node{
+		name:    name,
+		parent:  dir,
+		data:    data,
+		size:    uint32(len(data)),
+		mode:    0o644,
+		modTime: time.Now(),
+	}
+	dir.children[name] = node
+	return node, nil
+}
+
+// AddExistingFile inserts a file whose content is backed by a reader at a
+// sector location, used when building the tree from a parsed image.
+func (n *Node) AddExistingFile(path string, reader io.ReaderAt, location, size uint32, mode os.FileMode, modTime time.Time) (*Node, error) {
+	parts := splitPath(path)
+	if len(parts) == 0 {
+		return nil, fmt.Errorf("file path is empty")
+	}
+	name := StripVersion(parts[len(parts)-1])
+	dir, err := n.mkdirs(parts[:len(parts)-1])
+	if err != nil {
+		return nil, err
+	}
+	if existing := dir.children[name]; existing != nil && existing.isDir {
+		return nil, fmt.Errorf("path %q is a directory", existing.FullPath())
+	}
+	node := &Node{
+		name:     name,
+		parent:   dir,
+		reader:   reader,
+		location: location,
+		size:     size,
+		mode:     mode,
+		modTime:  modTime,
+	}
+	dir.children[name] = node
+	return node, nil
+}
+
+// Remove deletes the node at the given path. Removing a directory removes
+// its entire subtree. Removing the root or a missing path is an error.
+func (n *Node) Remove(path string) error {
+	target := n.Lookup(path)
+	if target == nil {
+		return fmt.Errorf("path not found: %s", path)
+	}
+	if target.parent == nil {
+		return fmt.Errorf("cannot remove the root directory")
+	}
+	delete(target.parent.children, target.name)
+	return nil
+}
+
+// Walk visits every node under n (excluding n itself) in depth-first
+// order, directories before their contents. Returning an error from fn
+// stops the walk.
+func (n *Node) Walk(fn func(node *Node) error) error {
+	for _, child := range n.Children() {
+		if err := fn(child); err != nil {
+			return err
+		}
+		if child.isDir {
+			if err := child.Walk(fn); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// Directories returns all directory nodes in breadth-first order starting
+// with (and including) n. This is the ordering required for path table
+// records: each parent appears before any of its children.
+func (n *Node) Directories() []*Node {
+	dirs := []*Node{n}
+	for i := 0; i < len(dirs); i++ {
+		for _, child := range dirs[i].Children() {
+			if child.isDir {
+				dirs = append(dirs, child)
+			}
+		}
+	}
+	return dirs
+}
+
+// Content returns a reader over the file's content, streaming from the
+// backing image when the content is not in memory. Calling Content on a
+// directory is an error.
+func (n *Node) Content(sectorSize int64) (io.Reader, error) {
+	if n.isDir {
+		return nil, fmt.Errorf("cannot read content of directory %q", n.FullPath())
+	}
+	if n.data != nil {
+		return bytes.NewReader(n.data), nil
+	}
+	if n.reader == nil {
+		if n.size == 0 {
+			return bytes.NewReader(nil), nil
+		}
+		return nil, fmt.Errorf("file %q has no content source", n.FullPath())
+	}
+	return io.NewSectionReader(n.reader, int64(n.location)*sectorSize, int64(n.size)), nil
+}
+
+// ContentReaderAt returns an io.ReaderAt over the file's content with
+// offset 0 at the start of the file, regardless of where the content is
+// stored. Calling ContentReaderAt on a directory is an error.
+func (n *Node) ContentReaderAt(sectorSize int64) (io.ReaderAt, error) {
+	if n.isDir {
+		return nil, fmt.Errorf("cannot read content of directory %q", n.FullPath())
+	}
+	if n.data != nil {
+		return bytes.NewReader(n.data), nil
+	}
+	if n.reader == nil {
+		if n.size == 0 {
+			return bytes.NewReader(nil), nil
+		}
+		return nil, fmt.Errorf("file %q has no content source", n.FullPath())
+	}
+	return io.NewSectionReader(n.reader, int64(n.location)*sectorSize, int64(n.size)), nil
+}
+
+// ReadData returns the file's content, either from memory or from the
+// backing reader. Calling ReadData on a directory is an error.
+func (n *Node) ReadData(sectorSize int64) ([]byte, error) {
+	if n.isDir {
+		return nil, fmt.Errorf("cannot read data of directory %q", n.FullPath())
+	}
+	if n.data != nil {
+		return n.data, nil
+	}
+	if n.reader == nil {
+		if n.size == 0 {
+			return []byte{}, nil
+		}
+		return nil, fmt.Errorf("file %q has no content source", n.FullPath())
+	}
+	buf := make([]byte, n.size)
+	if n.size == 0 {
+		return buf, nil
+	}
+	if _, err := n.reader.ReadAt(buf, int64(n.location)*sectorSize); err != nil {
+		return nil, fmt.Errorf("failed to read content of %q: %w", n.FullPath(), err)
+	}
+	return buf, nil
+}

--- a/pkg/iso9660/tree/tree_test.go
+++ b/pkg/iso9660/tree/tree_test.go
@@ -1,0 +1,130 @@
+package tree
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAddAndLookupFile(t *testing.T) {
+	root := NewRoot()
+
+	node, err := root.AddFile("docs/readme.txt", []byte("hello"))
+	require.NoError(t, err)
+	require.Equal(t, "readme.txt", node.Name())
+	require.Equal(t, "docs/readme.txt", node.FullPath())
+	require.True(t, node.IsPending())
+
+	// Parent directory was created implicitly.
+	docs := root.Lookup("docs")
+	require.NotNil(t, docs)
+	require.True(t, docs.IsDir())
+
+	// Lookup ignores leading slashes and version suffixes.
+	require.NotNil(t, root.Lookup("/docs/readme.txt"))
+	require.NotNil(t, root.Lookup("docs/readme.txt;1"))
+
+	data, err := node.ReadData(2048)
+	require.NoError(t, err)
+	require.Equal(t, []byte("hello"), data)
+}
+
+func TestAddFileReplacesExisting(t *testing.T) {
+	root := NewRoot()
+
+	_, err := root.AddFile("a.txt", []byte("one"))
+	require.NoError(t, err)
+	_, err = root.AddFile("a.txt", []byte("two"))
+	require.NoError(t, err)
+
+	data, err := root.Lookup("a.txt").ReadData(2048)
+	require.NoError(t, err)
+	require.Equal(t, []byte("two"), data)
+	require.Len(t, root.Children(), 1)
+}
+
+func TestFileDirectoryConflicts(t *testing.T) {
+	root := NewRoot()
+
+	_, err := root.AddFile("a", []byte("x"))
+	require.NoError(t, err)
+
+	// A file cannot become a path component.
+	_, err = root.AddFile("a/b.txt", []byte("y"))
+	require.Error(t, err)
+
+	// A directory cannot be replaced by a file.
+	_, err = root.AddDirectory("d")
+	require.NoError(t, err)
+	_, err = root.AddFile("d", []byte("z"))
+	require.Error(t, err)
+}
+
+func TestRemove(t *testing.T) {
+	root := NewRoot()
+
+	_, err := root.AddFile("dir/sub/file.txt", []byte("x"))
+	require.NoError(t, err)
+
+	require.NoError(t, root.Remove("dir/sub/file.txt"))
+	require.Nil(t, root.Lookup("dir/sub/file.txt"))
+	require.NotNil(t, root.Lookup("dir/sub"))
+
+	// Removing a directory removes its subtree.
+	require.NoError(t, root.Remove("dir"))
+	require.Nil(t, root.Lookup("dir"))
+
+	require.Error(t, root.Remove("missing"))
+	require.Error(t, root.Remove("/"))
+}
+
+func TestChildrenSorted(t *testing.T) {
+	root := NewRoot()
+	for _, name := range []string{"zeta", "alpha", "mid"} {
+		_, err := root.AddFile(name, nil)
+		require.NoError(t, err)
+	}
+	children := root.Children()
+	require.Equal(t, "alpha", children[0].Name())
+	require.Equal(t, "mid", children[1].Name())
+	require.Equal(t, "zeta", children[2].Name())
+}
+
+func TestDirectoriesBreadthFirst(t *testing.T) {
+	root := NewRoot()
+	for _, p := range []string{"b/deep", "a", "b", "a/nested/more"} {
+		_, err := root.AddDirectory(p)
+		require.NoError(t, err)
+	}
+
+	dirs := root.Directories()
+	var paths []string
+	for _, d := range dirs {
+		paths = append(paths, d.FullPath())
+	}
+	require.Equal(t, []string{"", "a", "b", "a/nested", "b/deep", "a/nested/more"}, paths)
+}
+
+func TestWalkOrder(t *testing.T) {
+	root := NewRoot()
+	_, err := root.AddFile("dir/file.txt", []byte("x"))
+	require.NoError(t, err)
+	_, err = root.AddFile("aaa.txt", []byte("y"))
+	require.NoError(t, err)
+
+	var visited []string
+	err = root.Walk(func(n *Node) error {
+		visited = append(visited, n.FullPath())
+		return nil
+	})
+	require.NoError(t, err)
+	require.Equal(t, []string{"aaa.txt", "dir", "dir/file.txt"}, visited)
+}
+
+func TestStripVersion(t *testing.T) {
+	require.Equal(t, "FILE.TXT", StripVersion("FILE.TXT;1"))
+	require.Equal(t, "FILE.TXT", StripVersion("FILE.TXT;12"))
+	require.Equal(t, "FILE.TXT", StripVersion("FILE.TXT"))
+	// A non-numeric suffix after ';' is part of the name.
+	require.Equal(t, "A;B", StripVersion("A;B"))
+}

--- a/pkg/iso9660/write_test.go
+++ b/pkg/iso9660/write_test.go
@@ -1,0 +1,253 @@
+package iso9660
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// saveToTempFile saves the image to a fresh temp file and returns the path.
+func saveToTempFile(t *testing.T, iso *ISO9660) string {
+	t.Helper()
+	f, err := os.CreateTemp(t.TempDir(), "isokit-*.iso")
+	require.NoError(t, err)
+	require.NoError(t, iso.Save(f))
+	require.NoError(t, f.Close())
+	return f.Name()
+}
+
+func TestCreateSaveOpenRoundTrip(t *testing.T) {
+	iso, err := Create("TESTVOL")
+	require.NoError(t, err)
+
+	require.NoError(t, iso.AddFile("hello.txt", []byte("hello world\n")))
+	require.NoError(t, iso.AddFile("dir/nested/data.bin", []byte{0xde, 0xad, 0xbe, 0xef}))
+	require.NoError(t, iso.AddDirectory("empty"))
+
+	path := saveToTempFile(t, iso)
+
+	// The image size must match the PVD's volume space size exactly.
+	fi, err := os.Stat(path)
+	require.NoError(t, err)
+	require.Equal(t, int64(iso.GetVolumeSize())*2048, fi.Size())
+
+	f, err := os.Open(path)
+	require.NoError(t, err)
+	defer f.Close()
+
+	reopened, err := Open(f)
+	require.NoError(t, err)
+	require.Equal(t, "TESTVOL", reopened.GetVolumeID())
+
+	data, err := reopened.ReadFile("hello.txt")
+	require.NoError(t, err)
+	require.Equal(t, []byte("hello world\n"), data)
+
+	data, err = reopened.ReadFile("dir/nested/data.bin")
+	require.NoError(t, err)
+	require.Equal(t, []byte{0xde, 0xad, 0xbe, 0xef}, data)
+
+	dirs, err := reopened.ListDirectories()
+	require.NoError(t, err)
+	var dirPaths []string
+	for _, d := range dirs {
+		dirPaths = append(dirPaths, d.FullPath)
+	}
+	require.Contains(t, dirPaths, "/dir")
+	require.Contains(t, dirPaths, "/dir/nested")
+	require.Contains(t, dirPaths, "/empty")
+
+	files, err := reopened.ListFiles()
+	require.NoError(t, err)
+	require.Len(t, files, 2)
+}
+
+func TestOpenModifySaveRoundTrip(t *testing.T) {
+	// Build a base image.
+	iso, err := Create("MODVOL")
+	require.NoError(t, err)
+	require.NoError(t, iso.AddFile("keep.txt", []byte("keep me")))
+	require.NoError(t, iso.AddFile("remove.txt", []byte("remove me")))
+	basePath := saveToTempFile(t, iso)
+
+	// Open it, modify it, save it to a second file.
+	base, err := os.Open(basePath)
+	require.NoError(t, err)
+	defer base.Close()
+
+	opened, err := Open(base)
+	require.NoError(t, err)
+
+	require.NoError(t, opened.AddFile("added.txt", []byte("new content")))
+	require.NoError(t, opened.RemoveFile("remove.txt"))
+	modPath := saveToTempFile(t, opened)
+
+	// Reopen the modified image and verify the changes.
+	mod, err := os.Open(modPath)
+	require.NoError(t, err)
+	defer mod.Close()
+
+	final, err := Open(mod)
+	require.NoError(t, err)
+
+	// The kept file's content survived a relocation: it was copied from
+	// the base image's extent into the rebuilt layout.
+	data, err := final.ReadFile("keep.txt")
+	require.NoError(t, err)
+	require.Equal(t, []byte("keep me"), data)
+
+	data, err = final.ReadFile("added.txt")
+	require.NoError(t, err)
+	require.Equal(t, []byte("new content"), data)
+
+	_, err = final.ReadFile("remove.txt")
+	require.Error(t, err)
+}
+
+func TestCreateLargeDirectory(t *testing.T) {
+	// Enough children that the root directory extent spans multiple
+	// sectors, exercising the sector-boundary placement rule.
+	iso, err := Create("BIGDIR")
+	require.NoError(t, err)
+
+	const fileCount = 200
+	for i := 0; i < fileCount; i++ {
+		require.NoError(t, iso.AddFile(
+			filepath.ToSlash(filepath.Join("files", fmtName(i))),
+			[]byte{byte(i)},
+		))
+	}
+
+	path := saveToTempFile(t, iso)
+
+	f, err := os.Open(path)
+	require.NoError(t, err)
+	defer f.Close()
+
+	reopened, err := Open(f)
+	require.NoError(t, err)
+
+	files, err := reopened.ListFiles()
+	require.NoError(t, err)
+	require.Len(t, files, fileCount)
+
+	// Spot-check content addressing across the extent.
+	for _, i := range []int{0, 99, 199} {
+		data, err := reopened.ReadFile("files/" + fmtName(i))
+		require.NoError(t, err)
+		require.Equal(t, []byte{byte(i)}, data)
+	}
+}
+
+func fmtName(i int) string {
+	return "FILE" + string(rune('A'+i/26%26)) + string(rune('A'+i%26)) + itoa(i) + ".DAT"
+}
+
+func itoa(i int) string {
+	if i == 0 {
+		return "0"
+	}
+	var digits []byte
+	for i > 0 {
+		digits = append([]byte{byte('0' + i%10)}, digits...)
+		i /= 10
+	}
+	return string(digits)
+}
+
+func TestEmptyImage(t *testing.T) {
+	iso, err := Create("EMPTY")
+	require.NoError(t, err)
+
+	path := saveToTempFile(t, iso)
+
+	f, err := os.Open(path)
+	require.NoError(t, err)
+	defer f.Close()
+
+	reopened, err := Open(f)
+	require.NoError(t, err)
+	require.Equal(t, "EMPTY", reopened.GetVolumeID())
+
+	files, err := reopened.ListFiles()
+	require.NoError(t, err)
+	require.Empty(t, files)
+}
+
+func TestPristineResaveUnchanged(t *testing.T) {
+	iso, err := Create("PRISTINE")
+	require.NoError(t, err)
+	require.NoError(t, iso.AddFile("a.txt", []byte("alpha")))
+	basePath := saveToTempFile(t, iso)
+
+	base, err := os.Open(basePath)
+	require.NoError(t, err)
+	defer base.Close()
+
+	opened, err := Open(base)
+	require.NoError(t, err)
+
+	// Unmodified: the rebuild path should still produce an equivalent,
+	// readable image (the pristine passthrough only rewrites parsed
+	// structures, so verify via a full reopen either way).
+	resavePath := saveToTempFile(t, opened)
+
+	re, err := os.Open(resavePath)
+	require.NoError(t, err)
+	defer re.Close()
+
+	reopened, err := Open(re)
+	require.NoError(t, err)
+	data, err := reopened.ReadFile("a.txt")
+	require.NoError(t, err)
+	require.Equal(t, []byte("alpha"), data)
+}
+
+// TestInterop validates the produced image with an external ISO tool
+// (isoinfo or xorriso) when one is available, ensuring other tools can
+// read what iso-kit writes.
+func TestInterop(t *testing.T) {
+	iso, err := Create("INTEROP")
+	require.NoError(t, err)
+	require.NoError(t, iso.AddFile("HELLO.TXT", []byte("interop test\n")))
+	require.NoError(t, iso.AddFile("SUB/NESTED.TXT", []byte("nested\n")))
+	path := saveToTempFile(t, iso)
+
+	if isoinfo, err := exec.LookPath("isoinfo"); err == nil {
+		out, err := exec.Command(isoinfo, "-d", "-i", path).CombinedOutput()
+		require.NoError(t, err, "isoinfo -d failed: %s", out)
+		require.Contains(t, string(out), "INTEROP")
+
+		out, err = exec.Command(isoinfo, "-f", "-i", path).CombinedOutput()
+		require.NoError(t, err, "isoinfo -f failed: %s", out)
+		require.Contains(t, string(out), "HELLO.TXT")
+		require.Contains(t, string(out), "NESTED.TXT")
+
+		out, err = exec.Command(isoinfo, "-x", "/HELLO.TXT;1", "-i", path).CombinedOutput()
+		require.NoError(t, err, "isoinfo -x failed: %s", out)
+		require.Equal(t, "interop test\n", string(out))
+		return
+	}
+
+	if xorriso, err := exec.LookPath("xorriso"); err == nil {
+		out, err := exec.Command(xorriso, "-indev", path, "-find", "/", "-exec", "lsdl").CombinedOutput()
+		require.NoError(t, err, "xorriso -find failed: %s", out)
+		require.Contains(t, string(out), "INTEROP")
+		require.Contains(t, string(out), "HELLO.TXT")
+		require.Contains(t, string(out), "NESTED.TXT")
+
+		extracted := filepath.Join(t.TempDir(), "extracted.txt")
+		out, err = exec.Command(xorriso, "-osirrox", "on", "-indev", path,
+			"-extract", "/HELLO.TXT", extracted).CombinedOutput()
+		require.NoError(t, err, "xorriso -extract failed: %s", out)
+		data, err := os.ReadFile(extracted)
+		require.NoError(t, err)
+		require.Equal(t, "interop test\n", string(data))
+		return
+	}
+
+	t.Skip("no external ISO tool (isoinfo/xorriso) available")
+}


### PR DESCRIPTION
## Summary

P1 of the roadmap: the library can now **create ISOs from scratch and modify existing ones**. This closes the biggest architectural gap identified in the analysis — the absence of a mutable directory tree and a sector layout engine.

### New: `pkg/iso9660/tree`
A mutable in-memory directory tree that becomes the source of truth between Open/Create and Save. Each file node carries either pending in-memory content or a (reader, sector, size) reference into the backing image — so modifying an opened ISO relocates existing extents by streaming them, never loading the whole image into memory. Operations: `AddFile`, `AddDirectory`, `AddExistingFile`, `Remove`, `Lookup` (version-suffix tolerant), `Walk`, breadth-first `Directories`.

### New: `pack.go` — the sector layout engine
- Directory extent sizing and marshaling with the ECMA-119 rule that records never cross a 2048-byte sector boundary (`.`/`..` entries prepended, zero-padding at boundaries)
- L-type and M-type path table builders (breadth-first numbering, parents before children)
- `Pack()` assigns sector locations to every structure and updates all PVD cross-references: VolumeSpaceSize, PathTableSize, both path table locations, the root directory record, and every extent's location/length

### API: file mutation on `ISO9660`
`ReadFile`, `AddFile`, `AddDirectory`, `AddLocalDirectory` (imports a local directory tree preserving mode/mtime), `RemoveFile`, `RemoveDirectory`. Mutations invalidate the parse-time entry cache; `ListFiles`/`ListDirectories` rebuild lazily from the tree.

### `Create()` and `Save()`
- `Create()` now returns a working image: initialized PVD (getters all work), terminator, empty tree; `WithRootDir` imports a local directory at creation
- `Save()` dispatches: unmodified opened images take the pristine passthrough; created/modified images are packed and fully rebuilt. Every allocated sector is written, so output size is exactly VolumeSpaceSize × 2048

### Known limitations (deferred by the roadmap, warned at save time)
- Rebuilt images drop Joliet SVDs and El Torito boot structures (P2 items; needs SVD typed fields and the El Torito marshal fixes)
- Rock Ridge attributes are not yet written (P2 SUSP/RR rewrite)
- No filename validation/uppercasing yet (P2); names round-trip byte-exact

## Test plan
- Tree unit tests: add/lookup/replace/remove, conflict handling, sorted children, BFS ordering, version-suffix stripping
- End-to-end: Create→AddFile→Save→Open→ReadFile; Open→modify→Save→Open (verifies extent relocation); 200-file multi-sector directory; empty image; image size == VolumeSpaceSize
- Interop: generated images verified with xorriso (tree listing and file extraction match); test uses isoinfo or xorriso when available, skips otherwise
- `go build`, `go vet`, full `go test ./...` clean