### PR TITLE
Add Rock Ridge write support with SUSP framework

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -118,14 +118,27 @@ Goal: create and modify ISOs. Largest and most architecturally significant phase
 
 Goal: proper extension support with spec-compliant serialization.
 
-- [ ] Implement SUSP framework (SP, CE, ER, ST, ES)
-  - Continuation areas for RR data exceeding System Use space
-- [ ] Rewrite `MarshalRockRidge` from scratch
-  - PX (36 bytes, both-endian), NM/SL (with flags), TF (7/17-byte ISO format),
-    CL/PL (both-endian), RR signature entry
-- [ ] Fix Rock Ridge unmarshal: add PN, CL, PL, RE, SF + fix TF/SL/NM parsing
-- [ ] Integrate Rock Ridge into write pipeline
-  - SP+ER in root, PX/NM/TF in every record, CE for overflow
+- [x] Implement SUSP framework (`pkg/iso9660/extensions/susp.go`)
+  - SP, CE, ER, ST, RR entry builders; continuation areas for RR data
+    exceeding System Use space (per-record chunks, never crossing a sector)
+- [x] Rewrite `MarshalRockRidge` from scratch
+  - PX (36 bytes, both-endian), NM/SL (with flags and multi-entry
+    continuation), TF (7-byte recording format), CL/PL (both-endian), RR
+    signature entry with correct flag bits
+- [x] Fix Rock Ridge unmarshal: add PN, CL, PL, RE, SF, CE + fix TF/SL/NM parsing
+  - TF honors flag-bit ordering and long/short form; SL decodes component
+    records (root/current/parent); NM continuation appends; parser follows
+    CE continuation chains (bounded against cycles)
+- [x] Integrate Rock Ridge into write pipeline
+  - SP in root ".", ER in continuation area, RR/PX/TF on every record
+    (including "." and ".."), NM per child, SL for symlinks, CE for overflow
+  - ISO identifiers mangled (uppercase, d-chars, 31-char cap, deterministic
+    ~N dedupe) with POSIX names preserved via NM
+  - Tree carries uid/gid and symlink nodes; AddLocalDirectory imports
+    symlinks; created images write RR by default
+    (`WithCreateRockRidgeEnabled(false)` to disable); opened images keep RR
+    iff the source had it
+  - Verified with xorriso: POSIX names, PX modes, and symlinks recognized
 - [ ] Complete Joliet write support
   - Separate UCS-2 directory tree, separate path tables, 64-char filename validation
 - [ ] Fix El Torito entry field offsets to match specification
@@ -135,7 +148,11 @@ Goal: proper extension support with spec-compliant serialization.
 - [ ] Integrate El Torito into Create/Save pipeline
 - [ ] Wire character validation into descriptor write path
 - [ ] Implement ISO 9660 filename validation (Level 1/2/3)
+  - Partially covered by the Rock Ridge identifier mangler; strict
+    level-selectable validation still open
 - [ ] Add multi-extent file assembly for reading (Level 3 / >4GB files)
+- [ ] Extract() should materialize Rock Ridge symlinks as symlinks
+  (currently written as empty files on extraction)
 
 ## P3: Advanced — UDF, Hybrid ISO, Production Readiness
 

--- a/pkg/iso9660/extensions/rockridge.go
+++ b/pkg/iso9660/extensions/rockridge.go
@@ -1,8 +1,6 @@
 package extensions
 
 import (
-	"bytes"
-	"encoding/binary"
 	"errors"
 	"github.com/bgrewell/iso-kit/pkg/iso9660/encoding"
 	"io/fs"
@@ -85,6 +83,22 @@ type RockRidgeExtensions struct {
 
 	// SF - Sparse file info (if applicable)
 	IsSparse *bool
+
+	// CE - Continuation of the system use area elsewhere on the volume.
+	// The parser follows this to merge entries recorded in the
+	// continuation area; it is not itself a Rock Ridge attribute.
+	Continuation *ContinuationArea
+}
+
+// ContinuationArea locates a SUSP continuation of a system use field, as
+// carried by a "CE" entry.
+type ContinuationArea struct {
+	// Logical block number of the continuation area
+	Block uint32
+	// Byte offset of the continuation within the block
+	Offset uint32
+	// Length in bytes of the continuation
+	Length uint32
 }
 
 // HasRockRidge determines if any Rock Ridge extensions were set.
@@ -96,112 +110,119 @@ func (r *RockRidgeExtensions) HasRockRidge() bool {
 		r.AccessTime != nil || r.IsSparse != nil
 }
 
+// UnmarshalRockRidge parses a system use field into Rock Ridge extensions.
+// If the field ends with a CE entry, the returned extensions carry a
+// Continuation pointer the caller must follow (see ParseInto) to pick up
+// the remaining entries.
 func UnmarshalRockRidge(data []byte) (*RockRidgeExtensions, error) {
-	if len(data) < 2 {
+	if len(data) < 4 {
 		return nil, errors.New("invalid Rock Ridge data")
 	}
-
 	rr := &RockRidgeExtensions{}
-	reader := bytes.NewReader(data)
+	if err := rr.ParseInto(data); err != nil {
+		return nil, err
+	}
+	return rr, nil
+}
 
-	for reader.Len() > 4 {
-		// Read signature (2-byte identifier)
-		var sig [2]byte
-		if err := binary.Read(reader, binary.LittleEndian, &sig); err != nil {
-			return nil, err
+// ParseInto parses a system use area (or a continuation of one) and merges
+// the entries into the receiver. NM entries with the continue flag append
+// to the accumulated alternate name, as do SL component continuations.
+func (rr *RockRidgeExtensions) ParseInto(data []byte) error {
+	offset := 0
+	// A fresh CE in this area replaces any CE already consumed by the
+	// caller; clear it so the caller can detect whether this area chains
+	// further.
+	rr.Continuation = nil
+
+	for offset+4 <= len(data) {
+		sig := string(data[offset : offset+2])
+		length := int(data[offset+2])
+
+		// A zero length or an ST entry terminates the area; unknown
+		// trailing pad bytes also stop cleanly here.
+		if length < 4 || offset+length > len(data) {
+			break
 		}
-		entryType := string(sig[:])
+		payload := data[offset+4 : offset+length]
+		offset += length
 
-		// Read length (1 byte)
-		var length byte
-		if err := binary.Read(reader, binary.LittleEndian, &length); err != nil {
-			return nil, err
-		}
-
-		// Read version (1 byte)
-		var version byte
-		if err := binary.Read(reader, binary.LittleEndian, &version); err != nil {
-			return nil, err
-		}
-
-		// Read payload
-		payloadLen := int(length) - 4
-		payload := make([]byte, payloadLen)
-		if _, err := reader.Read(payload); err != nil {
-			return nil, err
-		}
-
-		switch RockRidgeEntryType(entryType) {
-		case POSIX_FILE_PERMS: // PX (POSIX permissions)
+		switch RockRidgeEntryType(sig) {
+		case POSIX_FILE_PERMS: // PX: mode, nlink, uid, gid (+ optional serial)
 			if len(payload) >= 32 {
-				// Payload is the bytes from offset 4 to 36 (32 bytes) ... technically there are another 8 bytes for the
-				// file serial number but that generally hasn't been present so it is ignored here.
-				// Decode 8-byte File Mode (Permissions)
-				mode, err := encoding.UnmarshalUint32LSBMSB([8]byte(payload[0:8]))
-				if err == nil {
+				if mode, err := encoding.UnmarshalUint32LSBMSB([8]byte(payload[0:8])); err == nil {
 					permissions := parseFileMode(mode)
 					rr.Permissions = &permissions
 				}
-
-				// Decode 8-byte Number of Links
-				_, err = encoding.UnmarshalUint32LSBMSB([8]byte(payload[8:16]))
-				if err != nil {
-					return nil, errors.New("failed to parse PX link count")
-				}
-
-				// Decode 8-byte UID
-				uid, err := encoding.UnmarshalUint32LSBMSB([8]byte(payload[16:24]))
-				if err == nil {
+				if uid, err := encoding.UnmarshalUint32LSBMSB([8]byte(payload[16:24])); err == nil {
 					rr.UID = &uid
 				}
-
-				// Decode 8-byte GID
-				gid, err := encoding.UnmarshalUint32LSBMSB([8]byte(payload[24:32]))
-				if err == nil {
+				if gid, err := encoding.UnmarshalUint32LSBMSB([8]byte(payload[24:32])); err == nil {
 					rr.GID = &gid
 				}
 			}
-		case TIME_STAMPS: // TF (Timestamps)
-			// Rock Ridge TF entry uses a **variable-length encoding**
-			offset := 0
-			for offset < len(payload) {
-				flag := payload[offset]
-				offset++
 
-				if flag&0x01 != 0 && offset+7 <= len(payload) { // Creation time
-					seconds := int64(binary.LittleEndian.Uint32(payload[offset : offset+4]))
-					rr.CreationTime = new(time.Time)
-					*rr.CreationTime = time.Unix(seconds, 0)
-					offset += 7
+		case POSIX_DEVICE_NUM: // PN: major, minor
+			if len(payload) >= 16 {
+				if major, err := encoding.UnmarshalUint32LSBMSB([8]byte(payload[0:8])); err == nil {
+					rr.Major = &major
 				}
-
-				if flag&0x02 != 0 && offset+7 <= len(payload) { // Modification time
-					seconds := int64(binary.LittleEndian.Uint32(payload[offset : offset+4]))
-					rr.ModificationTime = new(time.Time)
-					*rr.ModificationTime = time.Unix(seconds, 0)
-					offset += 7
-				}
-
-				if flag&0x04 != 0 && offset+7 <= len(payload) { // Access time
-					seconds := int64(binary.LittleEndian.Uint32(payload[offset : offset+4]))
-					rr.AccessTime = new(time.Time)
-					*rr.AccessTime = time.Unix(seconds, 0)
-					offset += 7
+				if minor, err := encoding.UnmarshalUint32LSBMSB([8]byte(payload[8:16])); err == nil {
+					rr.Minor = &minor
 				}
 			}
 
-		case ALTERNATE_NAME: // NM (Alternate name)
-			// Flags (NM Flags) - 8-bit number. The following bits are defined:
-			// 	 Bit 0: Continuation - If set to 1, the Name Content record is continued in the next "NM" entry.
-			//   Bit 1: Current - If set to 1, the Name Content record refers to the current directory.
-			//   Bit 2: Parent - If set to 1, the Name Content record refers to the parent directory.
-			//   Bit 3: Reserved - Should be set to 0.
-			//   Bit 4: Reserved - Should be set to 0.
-			//   Bit 5: Historical - Historically contains the network node name.
-			//   Bit 6: Reserved - Should be set to 0.
-			//   Bit 7: Reserved - Should be set to 0.
+		case TIME_STAMPS: // TF: flag byte, then timestamps in flag-bit order
+			if len(payload) < 1 {
+				break
+			}
 			flags := payload[0]
-			rr.AlternateNameFlags = &NameEntryFlags{
+			stampLen := 7
+			longForm := flags&0x80 != 0
+			if longForm {
+				stampLen = 17
+			}
+			pos := 1
+			readStamp := func() (time.Time, bool) {
+				if pos+stampLen > len(payload) {
+					return time.Time{}, false
+				}
+				var t time.Time
+				var err error
+				if longForm {
+					t, err = encoding.UnmarshalDateTime([17]byte(payload[pos : pos+17]))
+				} else {
+					t, err = encoding.UnmarshalRecordingDateTime([7]byte(payload[pos : pos+7]))
+				}
+				pos += stampLen
+				return t, err == nil
+			}
+			// Timestamps appear in flag-bit order: creation, modify,
+			// access, attributes, backup, expiration, effective.
+			if flags&0x01 != 0 {
+				if t, ok := readStamp(); ok {
+					rr.CreationTime = &t
+				}
+			}
+			if flags&0x02 != 0 {
+				if t, ok := readStamp(); ok {
+					rr.ModificationTime = &t
+				}
+			}
+			if flags&0x04 != 0 {
+				if t, ok := readStamp(); ok {
+					rr.AccessTime = &t
+				}
+			}
+			// Remaining timestamp types (attributes, backup, expiration,
+			// effective) are consumed implicitly by stopping here.
+
+		case ALTERNATE_NAME: // NM: flags byte then name content
+			if len(payload) < 1 {
+				break
+			}
+			flags := payload[0]
+			nameFlags := &NameEntryFlags{
 				Continue:  flags&0x01 > 0,
 				Current:   flags&0x02 > 0,
 				Parent:    flags&0x04 > 0,
@@ -211,88 +232,209 @@ func UnmarshalRockRidge(data []byte) (*RockRidgeExtensions, error) {
 				Reserved4: flags&0x40 > 0,
 				Reserved5: flags&0x80 > 0,
 			}
-			rr.AlternateName = new(string)
-			*rr.AlternateName = string(payload[1:])
+			// A prior NM with the continue flag set means this content
+			// appends to the accumulated name.
+			if rr.AlternateName != nil && rr.AlternateNameFlags != nil && rr.AlternateNameFlags.Continue {
+				appended := *rr.AlternateName + string(payload[1:])
+				rr.AlternateName = &appended
+			} else {
+				name := string(payload[1:])
+				rr.AlternateName = &name
+			}
+			rr.AlternateNameFlags = nameFlags
 
-		case SYMBOLIC_LINK: // SL (Symbolic link)
-			rr.SymlinkTarget = new(string)
-			*rr.SymlinkTarget = string(payload[1:]) // Skip flags byte
+		case SYMBOLIC_LINK: // SL: flags byte then component records
+			if len(payload) < 1 {
+				break
+			}
+			continued := rr.SymlinkTarget != nil && rr.SymlinkFlags != nil && *rr.SymlinkFlags&0x01 != 0
+			prefix := ""
+			if continued {
+				prefix = *rr.SymlinkTarget
+			}
+			target := joinSLComponents(prefix, parseSLComponents(payload[1:]))
+			flags := payload[0]
+			rr.SymlinkFlags = &flags
+			rr.SymlinkTarget = &target
+
+		case CHILD_LINK: // CL: LBA of relocated directory
+			if len(payload) >= 8 {
+				if lba, err := encoding.UnmarshalUint32LSBMSB([8]byte(payload[0:8])); err == nil {
+					rr.ChildLinkLBA = &lba
+				}
+			}
+
+		case PARENT_LINK: // PL: LBA of original parent
+			if len(payload) >= 8 {
+				if lba, err := encoding.UnmarshalUint32LSBMSB([8]byte(payload[0:8])); err == nil {
+					rr.ParentLinkLBA = &lba
+				}
+			}
+
+		case RELOCATED_DIR: // RE: marker only
+			relocated := true
+			rr.IsRelocated = &relocated
+
+		case SPARSE_FILE: // SF: marker; virtual size details are not retained
+			sparse := true
+			rr.IsSparse = &sparse
+
+		case "CE": // SUSP continuation area pointer
+			if len(payload) >= 24 {
+				block, errB := encoding.UnmarshalUint32LSBMSB([8]byte(payload[0:8]))
+				areaOffset, errO := encoding.UnmarshalUint32LSBMSB([8]byte(payload[8:16]))
+				areaLen, errL := encoding.UnmarshalUint32LSBMSB([8]byte(payload[16:24]))
+				if errB == nil && errO == nil && errL == nil {
+					rr.Continuation = &ContinuationArea{Block: block, Offset: areaOffset, Length: areaLen}
+				}
+			}
+
+		case "ST": // SUSP terminator
+			return nil
+
+			// SP, ER, ES, and unknown entries are skipped.
 		}
 	}
 
-	return rr, nil
+	return nil
 }
 
-// MarshalRockRidge serializes Rock Ridge extension fields into ISO format.
+// parseSLComponents decodes SL component records into path components.
+// A root component is represented as "/".
+func parseSLComponents(data []byte) []string {
+	var components []string
+	pos := 0
+	for pos+2 <= len(data) {
+		flags := data[pos]
+		clen := int(data[pos+1])
+		pos += 2
+		if pos+clen > len(data) {
+			break
+		}
+		content := string(data[pos : pos+clen])
+		pos += clen
+
+		switch {
+		case flags&0x08 != 0: // root
+			components = append(components, "/")
+		case flags&0x02 != 0: // current directory
+			components = append(components, ".")
+		case flags&0x04 != 0: // parent directory
+			components = append(components, "..")
+		default:
+			components = append(components, content)
+		}
+	}
+	return components
+}
+
+// joinSLComponents assembles a symlink target from a previously
+// accumulated prefix (from an SL entry with the continue flag) and the
+// components of the current entry.
+func joinSLComponents(prefix string, components []string) string {
+	out := prefix
+	for _, c := range components {
+		switch {
+		case c == "/":
+			out += "/"
+		case out == "" || out == "/":
+			out += c
+		default:
+			out += "/" + c
+		}
+	}
+	return out
+}
+
+// MarshalRockRidge serializes Rock Ridge extension fields into a sequence
+// of correctly encoded SUSP/RRIP entries. The result is a flat byte
+// sequence; callers responsible for directory records must handle
+// splitting into continuation areas when the result does not fit the
+// record's system use field (see the pack layout engine).
 func MarshalRockRidge(rr *RockRidgeExtensions) ([]byte, error) {
-	var buf bytes.Buffer
-
-	//TODO: Fix this whole function, there were a lot of errors with sizes and offsets
-	if rr.UID != nil && rr.GID != nil && rr.Permissions != nil {
-		buf.Write([]byte("PX"))           // Signature
-		buf.WriteByte(10 + 4)             // Length (10 bytes data + header)
-		buf.WriteByte(ROCK_RIDGE_VERSION) // Version
-		binary.Write(&buf, binary.LittleEndian, *rr.UID)
-		binary.Write(&buf, binary.LittleEndian, *rr.GID)
-		binary.Write(&buf, binary.LittleEndian, *rr.Permissions)
+	entries, err := BuildRockRidgeEntries(rr)
+	if err != nil {
+		return nil, err
 	}
+	var out []byte
+	for _, e := range entries {
+		out = append(out, e...)
+	}
+	return out, nil
+}
 
+// BuildRockRidgeEntries produces the individual SUSP/RRIP entries for the
+// given extensions, in canonical order (RR, PX, PN, SL, NM, CL, PL, RE,
+// TF). Entries are returned separately so a layout engine can split them
+// between a record's system use field and a continuation area.
+func BuildRockRidgeEntries(rr *RockRidgeExtensions) ([][]byte, error) {
+	var entries [][]byte
+	var rrFlags byte
+
+	if rr.Permissions != nil {
+		rrFlags |= 0x01
+		var uid, gid uint32
+		if rr.UID != nil {
+			uid = *rr.UID
+		}
+		if rr.GID != nil {
+			gid = *rr.GID
+		}
+		entries = append(entries, BuildPX(*rr.Permissions, 1, uid, gid))
+	}
 	if rr.Major != nil && rr.Minor != nil {
-		buf.Write([]byte("PN"))           // Signature
-		buf.WriteByte(8 + 4)              // Length (8 bytes data + header)
-		buf.WriteByte(ROCK_RIDGE_VERSION) // Version
-		binary.Write(&buf, binary.LittleEndian, *rr.Major)
-		binary.Write(&buf, binary.LittleEndian, *rr.Minor)
+		rrFlags |= 0x02
+		entries = append(entries, BuildPN(*rr.Major, *rr.Minor))
 	}
-
 	if rr.SymlinkTarget != nil {
-		buf.Write([]byte("SL")) // Signature
-		buf.WriteByte(byte(len(*rr.SymlinkTarget) + 4))
-		buf.WriteByte(ROCK_RIDGE_VERSION)
-		buf.WriteString(*rr.SymlinkTarget)
+		rrFlags |= 0x04
+		slEntries, err := BuildSL(*rr.SymlinkTarget)
+		if err != nil {
+			return nil, err
+		}
+		entries = append(entries, slEntries...)
 	}
-
 	if rr.AlternateName != nil {
-		buf.Write([]byte("NM")) // Signature
-		buf.WriteByte(byte(len(*rr.AlternateName) + 4))
-		buf.WriteByte(ROCK_RIDGE_VERSION)
-		buf.WriteString(*rr.AlternateName)
+		rrFlags |= 0x08
+		entries = append(entries, BuildNM(*rr.AlternateName)...)
 	}
-
 	if rr.ChildLinkLBA != nil {
-		buf.Write([]byte("CL")) // Signature
-		buf.WriteByte(4 + 4)
-		buf.WriteByte(ROCK_RIDGE_VERSION)
-		binary.Write(&buf, binary.LittleEndian, *rr.ChildLinkLBA)
+		rrFlags |= 0x10
+		entries = append(entries, BuildCL(*rr.ChildLinkLBA))
 	}
-
 	if rr.ParentLinkLBA != nil {
-		buf.Write([]byte("PL")) // Signature
-		buf.WriteByte(4 + 4)
-		buf.WriteByte(ROCK_RIDGE_VERSION)
-		binary.Write(&buf, binary.LittleEndian, *rr.ParentLinkLBA)
+		rrFlags |= 0x20
+		entries = append(entries, BuildPL(*rr.ParentLinkLBA))
 	}
-
 	if rr.IsRelocated != nil && *rr.IsRelocated {
-		buf.Write([]byte("RE")) // Signature
-		buf.WriteByte(4)
-		buf.WriteByte(ROCK_RIDGE_VERSION)
+		rrFlags |= 0x40
+		entries = append(entries, BuildRE())
 	}
 
+	var creation, modification, access time.Time
 	if rr.CreationTime != nil {
-		buf.Write([]byte("TF")) // Signature
-		buf.WriteByte(7 + 4)
-		buf.WriteByte(ROCK_RIDGE_VERSION)
-		binary.Write(&buf, binary.LittleEndian, uint32(rr.CreationTime.Unix()))
+		creation = *rr.CreationTime
+	}
+	if rr.ModificationTime != nil {
+		modification = *rr.ModificationTime
+	}
+	if rr.AccessTime != nil {
+		access = *rr.AccessTime
+	}
+	if !creation.IsZero() || !modification.IsZero() || !access.IsZero() {
+		rrFlags |= 0x80
+		tf, err := BuildTF(creation, modification, access)
+		if err != nil {
+			return nil, err
+		}
+		entries = append(entries, tf)
 	}
 
-	if rr.IsSparse != nil && *rr.IsSparse {
-		buf.Write([]byte("SF")) // Signature
-		buf.WriteByte(4)
-		buf.WriteByte(ROCK_RIDGE_VERSION)
+	if len(entries) == 0 {
+		return nil, nil
 	}
-
-	return buf.Bytes(), nil
+	// The legacy RR entry announcing which fields follow leads the area.
+	return append([][]byte{BuildRR(rrFlags)}, entries...), nil
 }
 
 // parseFileMode converts a 32-bit unsigned integer into an fs.FileMode struct

--- a/pkg/iso9660/extensions/susp.go
+++ b/pkg/iso9660/extensions/susp.go
@@ -1,0 +1,310 @@
+package extensions
+
+import (
+	"fmt"
+	"io/fs"
+	"time"
+
+	"github.com/bgrewell/iso-kit/pkg/iso9660/encoding"
+)
+
+// System Use Sharing Protocol (SUSP, IEEE P1281) and Rock Ridge
+// Interchange Protocol (RRIP, IEEE P1282) entry builders. Every entry
+// shares a 4-byte header: signature (2), length (1), version (1).
+
+const (
+	SUSP_VERSION = 1
+
+	// RRIP ER identification strings (RRIP 1.09, as written by mkisofs
+	// and libisofs).
+	RRIP_ER_ID         = "RRIP_1991A"
+	RRIP_ER_DESCRIPTOR = "THE ROCK RIDGE INTERCHANGE PROTOCOL PROVIDES SUPPORT FOR POSIX FILE SYSTEM SEMANTICS"
+	RRIP_ER_SOURCE     = "PLEASE CONTACT DISC PUBLISHER FOR SPECIFICATION SOURCE.  SEE PUBLISHER IDENTIFIER IN PRIMARY VOLUME DESCRIPTOR FOR CONTACT INFORMATION."
+
+	// TF flag bits (RRIP 4.1.6).
+	TF_CREATION   = 0x01
+	TF_MODIFY     = 0x02
+	TF_ACCESS     = 0x04
+	TF_ATTRIBUTES = 0x08
+	TF_BACKUP     = 0x10
+	TF_EXPIRATION = 0x20
+	TF_EFFECTIVE  = 0x40
+	TF_LONG_FORM  = 0x80
+
+	// NM/SL component flag bits.
+	NM_CONTINUE = 0x01
+	NM_CURRENT  = 0x02
+	NM_PARENT   = 0x04
+
+	SL_COMPONENT_CONTINUE = 0x01
+	SL_COMPONENT_CURRENT  = 0x02
+	SL_COMPONENT_PARENT   = 0x04
+	SL_COMPONENT_ROOT     = 0x08
+
+	// The system use field lives inside a directory record, which is
+	// itself capped at 255 bytes; entries must be built small enough to
+	// fit either inline or in a continuation area within one sector.
+	MAX_ENTRY_PAYLOAD = 240
+)
+
+func suspHeader(signature string, length int) []byte {
+	return []byte{signature[0], signature[1], byte(length), SUSP_VERSION}
+}
+
+// BuildSP returns the SUSP "SP" entry (7 bytes) that announces System Use
+// Sharing Protocol use. It must appear in the system use area of the root
+// directory's "." record. skip is the number of bytes to skip at the start
+// of each system use field (0 unless interoperating with legacy layouts).
+func BuildSP(skip byte) []byte {
+	entry := suspHeader("SP", 7)
+	return append(entry, 0xBE, 0xEF, skip)
+}
+
+// BuildCE returns the SUSP "CE" entry (28 bytes) pointing at a
+// continuation of the system use area: block is the logical block number
+// of the continuation, offset the starting byte within that block, and
+// length the number of continuation bytes.
+func BuildCE(block, offset, length uint32) []byte {
+	entry := suspHeader("CE", 28)
+	blockBytes := encoding.MarshalBothByteOrders32(block)
+	offsetBytes := encoding.MarshalBothByteOrders32(offset)
+	lengthBytes := encoding.MarshalBothByteOrders32(length)
+	entry = append(entry, blockBytes[:]...)
+	entry = append(entry, offsetBytes[:]...)
+	entry = append(entry, lengthBytes[:]...)
+	return entry
+}
+
+// BuildER returns the SUSP "ER" entry identifying the Rock Ridge
+// extensions in use. It is conventionally placed in a continuation area
+// referenced from the root "." record, since at 237 bytes it rarely fits
+// inline.
+func BuildER() []byte {
+	id, desc, src := RRIP_ER_ID, RRIP_ER_DESCRIPTOR, RRIP_ER_SOURCE
+	length := 8 + len(id) + len(desc) + len(src)
+	entry := suspHeader("ER", length)
+	entry = append(entry, byte(len(id)), byte(len(desc)), byte(len(src)), 1)
+	entry = append(entry, id...)
+	entry = append(entry, desc...)
+	entry = append(entry, src...)
+	return entry
+}
+
+// BuildST returns the SUSP "ST" entry (4 bytes) terminating a system use
+// area. Optional under SUSP 1.12; provided for completeness.
+func BuildST() []byte {
+	return suspHeader("ST", 4)
+}
+
+// BuildRR returns the legacy "RR" entry (5 bytes) from RRIP 1.09 whose
+// flag byte advertises which RRIP entries follow in this system use area.
+// Widely written by mkisofs for compatibility with older readers.
+// Flag bits: 0=PX, 1=PN, 2=SL, 3=NM, 4=CL, 5=PL, 6=RE, 7=TF.
+func BuildRR(flags byte) []byte {
+	entry := suspHeader("RR", 5)
+	return append(entry, flags)
+}
+
+// BuildPX returns the RRIP "PX" entry (36 bytes, RRIP 1.09 form without
+// the file serial number) carrying POSIX mode, link count, uid, and gid.
+func BuildPX(mode fs.FileMode, nlink, uid, gid uint32) []byte {
+	entry := suspHeader("PX", 36)
+	modeBytes := encoding.MarshalBothByteOrders32(PosixMode(mode))
+	nlinkBytes := encoding.MarshalBothByteOrders32(nlink)
+	uidBytes := encoding.MarshalBothByteOrders32(uid)
+	gidBytes := encoding.MarshalBothByteOrders32(gid)
+	entry = append(entry, modeBytes[:]...)
+	entry = append(entry, nlinkBytes[:]...)
+	entry = append(entry, uidBytes[:]...)
+	entry = append(entry, gidBytes[:]...)
+	return entry
+}
+
+// BuildPN returns the RRIP "PN" entry (20 bytes) carrying the major and
+// minor device numbers of a block or character device node.
+func BuildPN(major, minor uint32) []byte {
+	entry := suspHeader("PN", 20)
+	majorBytes := encoding.MarshalBothByteOrders32(major)
+	minorBytes := encoding.MarshalBothByteOrders32(minor)
+	entry = append(entry, majorBytes[:]...)
+	entry = append(entry, minorBytes[:]...)
+	return entry
+}
+
+// BuildNM returns one or more RRIP "NM" entries carrying the alternate
+// (POSIX) name. Names longer than a single entry's capacity are split
+// across multiple entries chained with the continue flag.
+func BuildNM(name string) [][]byte {
+	var entries [][]byte
+	remaining := []byte(name)
+	for {
+		chunk := remaining
+		flags := byte(0)
+		if len(chunk) > MAX_ENTRY_PAYLOAD {
+			chunk = chunk[:MAX_ENTRY_PAYLOAD]
+			flags = NM_CONTINUE
+		}
+		entry := suspHeader("NM", 5+len(chunk))
+		entry = append(entry, flags)
+		entry = append(entry, chunk...)
+		entries = append(entries, entry)
+		remaining = remaining[len(chunk):]
+		if len(remaining) == 0 {
+			return entries
+		}
+	}
+}
+
+// BuildSL returns one or more RRIP "SL" entries encoding a symbolic link
+// target as component records. Each component is (flags, length, content);
+// "/" produces a root component, "." current, ".." parent.
+func BuildSL(target string) ([][]byte, error) {
+	var components [][]byte
+	appendComponent := func(flags byte, content string) {
+		components = append(components, append([]byte{flags, byte(len(content))}, content...))
+	}
+
+	rest := target
+	if len(rest) > 0 && rest[0] == '/' {
+		appendComponent(SL_COMPONENT_ROOT, "")
+		for len(rest) > 0 && rest[0] == '/' {
+			rest = rest[1:]
+		}
+	}
+	for _, part := range splitSlash(rest) {
+		switch part {
+		case "":
+			continue
+		case ".":
+			appendComponent(SL_COMPONENT_CURRENT, "")
+		case "..":
+			appendComponent(SL_COMPONENT_PARENT, "")
+		default:
+			if len(part) > MAX_ENTRY_PAYLOAD {
+				return nil, fmt.Errorf("symlink path component too long (%d bytes): %q", len(part), part)
+			}
+			appendComponent(0, part)
+		}
+	}
+
+	// Pack whole components into SL entries; a component never splits
+	// across entries here, so each entry's flag is either 0 (final) or
+	// continue.
+	var entries [][]byte
+	var payload []byte
+	flush := func(more bool) {
+		flags := byte(0)
+		if more {
+			flags = SL_COMPONENT_CONTINUE
+		}
+		entry := suspHeader("SL", 5+len(payload))
+		entry = append(entry, flags)
+		entry = append(entry, payload...)
+		entries = append(entries, entry)
+		payload = nil
+	}
+	for _, comp := range components {
+		if len(payload)+len(comp) > MAX_ENTRY_PAYLOAD {
+			flush(true)
+		}
+		payload = append(payload, comp...)
+	}
+	flush(false)
+	return entries, nil
+}
+
+// BuildCL returns the RRIP "CL" entry (12 bytes) linking a relocated
+// directory's placeholder to its actual extent.
+func BuildCL(lba uint32) []byte {
+	entry := suspHeader("CL", 12)
+	lbaBytes := encoding.MarshalBothByteOrders32(lba)
+	return append(entry, lbaBytes[:]...)
+}
+
+// BuildPL returns the RRIP "PL" entry (12 bytes) linking a relocated
+// directory's ".." record back to its original parent.
+func BuildPL(lba uint32) []byte {
+	entry := suspHeader("PL", 12)
+	lbaBytes := encoding.MarshalBothByteOrders32(lba)
+	return append(entry, lbaBytes[:]...)
+}
+
+// BuildRE returns the RRIP "RE" entry (4 bytes) marking a relocated
+// directory.
+func BuildRE() []byte {
+	return suspHeader("RE", 4)
+}
+
+// BuildTF returns the RRIP "TF" entry carrying timestamps in the 7-byte
+// recording date/time form. Zero times are omitted from the entry.
+func BuildTF(creation, modification, access time.Time) ([]byte, error) {
+	var flags byte
+	var stamps []time.Time
+	add := func(t time.Time, bit byte) {
+		if !t.IsZero() {
+			flags |= bit
+			stamps = append(stamps, t)
+		}
+	}
+	add(creation, TF_CREATION)
+	add(modification, TF_MODIFY)
+	add(access, TF_ACCESS)
+
+	entry := suspHeader("TF", 5+7*len(stamps))
+	entry = append(entry, flags)
+	for _, t := range stamps {
+		stamp, err := encoding.MarshalRecordingDateTime(t)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal TF timestamp: %w", err)
+		}
+		entry = append(entry, stamp[:]...)
+	}
+	return entry, nil
+}
+
+// PosixMode converts an fs.FileMode into POSIX st_mode bits (file type and
+// permissions), the inverse of parseFileMode.
+func PosixMode(mode fs.FileMode) uint32 {
+	var m uint32
+
+	switch {
+	case mode&fs.ModeSymlink != 0:
+		m = 0xA000 // S_IFLNK
+	case mode&fs.ModeDir != 0:
+		m = 0x4000 // S_IFDIR
+	case mode&fs.ModeSocket != 0:
+		m = 0xC000 // S_IFSOCK
+	case mode&fs.ModeCharDevice != 0:
+		m = 0x2000 // S_IFCHR
+	case mode&fs.ModeDevice != 0:
+		m = 0x6000 // S_IFBLK
+	case mode&fs.ModeNamedPipe != 0:
+		m = 0x1000 // S_IFIFO
+	default:
+		m = 0x8000 // S_IFREG
+	}
+
+	m |= uint32(mode.Perm())
+	if mode&fs.ModeSetuid != 0 {
+		m |= 0x0800
+	}
+	if mode&fs.ModeSetgid != 0 {
+		m |= 0x0400
+	}
+	if mode&fs.ModeSticky != 0 {
+		m |= 0x0200
+	}
+	return m
+}
+
+func splitSlash(s string) []string {
+	var parts []string
+	start := 0
+	for i := 0; i <= len(s); i++ {
+		if i == len(s) || s[i] == '/' {
+			parts = append(parts, s[start:i])
+			start = i + 1
+		}
+	}
+	return parts
+}

--- a/pkg/iso9660/iso9660.go
+++ b/pkg/iso9660/iso9660.go
@@ -149,18 +149,28 @@ func Open(isoReader io.ReaderAt, opts ...option.OpenOption) (*ISO9660, error) {
 	// becomes the source of truth for Save.
 	root := tree.NewRoot()
 	for _, entry := range filesystemEntries {
-		if entry.IsDir {
-			node, err := root.AddDirectory(entry.FullPath)
-			if err != nil {
-				return nil, fmt.Errorf("failed to build directory tree: %w", err)
+		var node *tree.Node
+		record := entry.DirectoryRecord()
+		switch {
+		case entry.IsDir:
+			node, err = root.AddDirectory(entry.FullPath)
+			if err == nil {
+				node.SetMode(entry.Mode)
+				node.SetModTime(entry.ModTime)
 			}
-			node.SetMode(entry.Mode)
-			node.SetModTime(entry.ModTime)
-		} else {
-			_, err := root.AddExistingFile(entry.FullPath, isoReader, entry.Location, entry.Size, entry.Mode, entry.ModTime)
-			if err != nil {
-				return nil, fmt.Errorf("failed to build directory tree: %w", err)
+		case record != nil && record.RockRidge != nil && record.RockRidge.SymlinkTarget != nil:
+			node, err = root.AddSymlink(entry.FullPath, *record.RockRidge.SymlinkTarget)
+			if err == nil {
+				node.SetModTime(entry.ModTime)
 			}
+		default:
+			node, err = root.AddExistingFile(entry.FullPath, isoReader, entry.Location, entry.Size, entry.Mode, entry.ModTime)
+		}
+		if err != nil {
+			return nil, fmt.Errorf("failed to build directory tree: %w", err)
+		}
+		if entry.UID != nil && entry.GID != nil {
+			node.SetOwnership(*entry.UID, *entry.GID)
 		}
 	}
 
@@ -186,8 +196,9 @@ func Open(isoReader io.ReaderAt, opts ...option.OpenOption) (*ISO9660, error) {
 func Create(name string, opts ...option.CreateOption) (*ISO9660, error) {
 	// Set default create options
 	createOptions := &option.CreateOptions{
-		Preparer: fmt.Sprintf("iso-kit %s %s (%s) %s", version.Version(), version.Revision(), version.Branch(), version.Date()),
-		Logger:   logging.DefaultLogger(),
+		Preparer:         fmt.Sprintf("iso-kit %s %s (%s) %s", version.Version(), version.Revision(), version.Branch(), version.Date()),
+		RockRidgeEnabled: true,
+		Logger:           logging.DefaultLogger(),
 	}
 
 	for _, opt := range opts {
@@ -679,6 +690,18 @@ func (iso *ISO9660) AddLocalDirectory(sourcePath, targetPath string) error {
 			node.SetModTime(fi.ModTime())
 			return nil
 		}
+		if fi.Mode()&os.ModeSymlink != 0 {
+			target, err := os.Readlink(path)
+			if err != nil {
+				return fmt.Errorf("failed to read symlink %s: %w", path, err)
+			}
+			node, err := iso.root.AddSymlink(isoPath, target)
+			if err != nil {
+				return err
+			}
+			node.SetModTime(fi.ModTime())
+			return nil
+		}
 		if !fi.Mode().IsRegular() {
 			iso.logger.Info("Skipping non-regular file", "path", path)
 			return nil
@@ -1031,9 +1054,17 @@ func (iso *ISO9660) saveRebuild(writer io.WriterAt) error {
 	}
 	iso.pathTables = []*pathtable.PathTable{ptL, ptM}
 
-	// 5. Directory extents in breadth-first order.
+	// 5. Rock Ridge continuation area (ER entry and overflow), if any.
+	if contData := iso.marshalContinuationArea(); contData != nil {
+		contOffset := int64(iso.layout.contBaseSector) * consts.ISO9660_SECTOR_SIZE
+		if _, err := writer.WriteAt(contData, contOffset); err != nil {
+			return fmt.Errorf("failed to write Rock Ridge continuation area: %w", err)
+		}
+	}
+
+	// 6. Directory extents in breadth-first order.
 	for _, dir := range iso.layout.dirs {
-		data, err := marshalDirectoryExtent(dir)
+		data, err := marshalDirectoryExtent(dir, iso.layout.plans[dir])
 		if err != nil {
 			return err
 		}
@@ -1042,7 +1073,7 @@ func (iso *ISO9660) saveRebuild(writer io.WriterAt) error {
 		}
 	}
 
-	// 6. File extents, each zero-padded to whole sectors.
+	// 7. File extents, each zero-padded to whole sectors.
 	for _, file := range iso.layout.files {
 		if err := iso.writeFileExtent(writer, file); err != nil {
 			return err

--- a/pkg/iso9660/names.go
+++ b/pkg/iso9660/names.go
@@ -1,0 +1,116 @@
+package iso9660
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/bgrewell/iso-kit/pkg/iso9660/tree"
+)
+
+// Maximum identifier length (excluding the ";1" version suffix) when
+// mangling for Rock Ridge images. ISO 9660 Level 2 allows up to 31
+// characters; the original name is preserved in the NM entry.
+const mangledIdentifierMaxLen = 31
+
+// mangleISOName converts a POSIX name into a valid ISO 9660 identifier:
+// uppercase d-characters, at most one "." separator (files only), length
+// capped at mangledIdentifierMaxLen. Used when Rock Ridge is enabled, in
+// which case the original name travels in the NM entry.
+func mangleISOName(name string, isDir bool) string {
+	base, ext := name, ""
+	if !isDir {
+		if i := strings.LastIndexByte(name, '.'); i > 0 && i < len(name)-1 {
+			base, ext = name[:i], name[i+1:]
+		}
+	}
+
+	mangle := func(s string) string {
+		out := make([]byte, 0, len(s))
+		for _, r := range strings.ToUpper(s) {
+			switch {
+			case r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '_':
+				out = append(out, byte(r))
+			default:
+				out = append(out, '_')
+			}
+		}
+		return string(out)
+	}
+
+	base = mangle(base)
+	ext = mangle(ext)
+
+	if isDir || ext == "" {
+		if len(base) > mangledIdentifierMaxLen {
+			base = base[:mangledIdentifierMaxLen]
+		}
+		if base == "" {
+			base = "_"
+		}
+		return base
+	}
+
+	// Keep the extension (up to 3 characters is conventional; longer is
+	// tolerated by Level 2 readers, but trim to keep the total in range).
+	if len(ext) > 3 {
+		ext = ext[:3]
+	}
+	maxBase := mangledIdentifierMaxLen - len(ext) - 1
+	if len(base) > maxBase {
+		base = base[:maxBase]
+	}
+	if base == "" {
+		base = "_"
+	}
+	return base + "." + ext
+}
+
+// assignIdentifiers produces the on-disk identifier for every child of a
+// directory. With mangling enabled (Rock Ridge), names are converted to
+// valid identifiers and collisions are resolved deterministically with a
+// numeric tail; otherwise names are used as-is. File identifiers carry the
+// ";1" version suffix.
+func assignIdentifiers(children []*tree.Node, mangled bool) map[*tree.Node]string {
+	out := make(map[*tree.Node]string, len(children))
+	used := make(map[string]bool, len(children))
+
+	for _, child := range children {
+		var id string
+		if mangled {
+			id = mangleISOName(child.Name(), child.IsDir())
+			if used[id] {
+				id = dedupeIdentifier(id, child.IsDir(), used)
+			}
+		} else {
+			id = child.Name()
+		}
+		used[id] = true
+		if !child.IsDir() {
+			id += ";1"
+		}
+		out[child] = id
+	}
+	return out
+}
+
+// dedupeIdentifier resolves an identifier collision by replacing the tail
+// of the base name with ~N, preserving the extension.
+func dedupeIdentifier(id string, isDir bool, used map[string]bool) string {
+	base, ext := id, ""
+	if !isDir {
+		if i := strings.LastIndexByte(id, '.'); i > 0 {
+			base, ext = id[:i], id[i:]
+		}
+	}
+	for n := 1; ; n++ {
+		tail := fmt.Sprintf("~%d", n)
+		trimmed := base
+		if len(trimmed)+len(tail)+len(ext) > mangledIdentifierMaxLen {
+			trimmed = trimmed[:mangledIdentifierMaxLen-len(tail)-len(ext)]
+		}
+		candidate := trimmed + tail + ext
+		if !used[candidate] {
+			return candidate
+		}
+	}
+}

--- a/pkg/iso9660/pack.go
+++ b/pkg/iso9660/pack.go
@@ -2,10 +2,12 @@ package iso9660
 
 import (
 	"fmt"
+	"io/fs"
 	"time"
 
 	"github.com/bgrewell/iso-kit/pkg/consts"
 	"github.com/bgrewell/iso-kit/pkg/iso9660/directory"
+	"github.com/bgrewell/iso-kit/pkg/iso9660/extensions"
 	"github.com/bgrewell/iso-kit/pkg/iso9660/pathtable"
 	"github.com/bgrewell/iso-kit/pkg/iso9660/tree"
 )
@@ -15,12 +17,18 @@ const (
 	// length(1) + xattr(1) + extent(8) + data length(8) + timestamp(7) +
 	// flags(1) + unit size(1) + gap size(1) + volume sequence(4) + id length(1).
 	directoryRecordFixedSize = 33
+
+	// A directory record's total length is stored in one byte.
+	maxDirectoryRecordLen = 255
+
+	// On-disk size of a SUSP "CE" continuation pointer entry.
+	ceEntrySize = 28
 )
 
-// directoryRecordLength returns the on-disk length of a directory record
-// for an identifier of the given byte length. A pad byte follows the
-// identifier when its length is even, keeping the record length even.
-func directoryRecordLength(identifierLen int) int {
+// directoryRecordBaseLength returns the length of a directory record for
+// the given identifier before any system use data: the fixed fields, the
+// identifier, and its pad byte when the identifier length is even.
+func directoryRecordBaseLength(identifierLen int) int {
 	length := directoryRecordFixedSize + identifierLen
 	if identifierLen%2 == 0 {
 		length++
@@ -28,45 +36,341 @@ func directoryRecordLength(identifierLen int) int {
 	return length
 }
 
-// isoFileIdentifier returns the on-disk identifier for a node: files carry
-// the ISO 9660 ";1" version suffix, directories do not.
-func isoFileIdentifier(node *tree.Node) string {
-	if node.IsDir() {
-		return node.Name()
-	}
-	return node.Name() + ";1"
-}
-
 // sectorsFor returns the number of whole sectors needed for size bytes.
 func sectorsFor(size uint32) uint32 {
 	return (size + consts.ISO9660_SECTOR_SIZE - 1) / consts.ISO9660_SECTOR_SIZE
 }
 
-// directoryExtentSize computes the size in bytes of a directory's extent:
-// the "." and ".." records plus one record per child, laid out so no record
-// crosses a sector boundary, rounded up to a whole sector.
-func directoryExtentSize(dir *tree.Node) uint32 {
-	offset := directoryRecordLength(1) * 2 // "." and ".."
+// recordPlan describes one directory record to be written: its on-disk
+// identifier and the SUSP entries destined for its system use field,
+// split between the inline portion and a continuation area.
+type recordPlan struct {
+	identifier    string
+	inlineEntries [][]byte
+	contEntries   [][]byte
+	// Absolute sector and byte offset of this record's continuation
+	// chunk, assigned during layout when contEntries is non-empty.
+	contBlock  uint32
+	contOffset uint32
+}
+
+func entriesLen(entries [][]byte) int {
+	total := 0
+	for _, e := range entries {
+		total += len(e)
+	}
+	return total
+}
+
+func (p *recordPlan) contLen() int {
+	return entriesLen(p.contEntries)
+}
+
+// suLen returns the size of the record's inline system use field: the
+// inline entries, a CE pointer when a continuation exists, and a pad byte
+// keeping the record length even.
+func (p *recordPlan) suLen() int {
+	length := entriesLen(p.inlineEntries)
+	if len(p.contEntries) > 0 {
+		length += ceEntrySize
+	}
+	if length%2 != 0 {
+		length++
+	}
+	return length
+}
+
+// recordLen returns the record's total on-disk length.
+func (p *recordPlan) recordLen() int {
+	return directoryRecordBaseLength(len(p.identifier)) + p.suLen()
+}
+
+// systemUse assembles the record's inline system use field. Continuation
+// locations must already be assigned.
+func (p *recordPlan) systemUse() []byte {
+	var su []byte
+	for _, e := range p.inlineEntries {
+		su = append(su, e...)
+	}
+	if len(p.contEntries) > 0 {
+		su = append(su, extensions.BuildCE(p.contBlock, p.contOffset, uint32(p.contLen()))...)
+	}
+	if len(su)%2 != 0 {
+		su = append(su, 0x00)
+	}
+	return su
+}
+
+// continuationData returns the bytes of the record's continuation chunk.
+func (p *recordPlan) continuationData() []byte {
+	var out []byte
+	for _, e := range p.contEntries {
+		out = append(out, e...)
+	}
+	return out
+}
+
+// splitEntries distributes SUSP entries between the inline system use
+// field and a continuation area. lead entries are always inline (SP must
+// stay in the record); forcedCont entries always go to the continuation
+// (ER, which never fits). budget is the record's available system use
+// space.
+func splitEntries(lead, entries, forcedCont [][]byte, budget int) (inline, cont [][]byte, err error) {
+	inline = append(inline, lead...)
+	inlineLen := entriesLen(lead)
+
+	// First try: everything inline, no CE needed.
+	if len(forcedCont) == 0 && inlineLen+entriesLen(entries)+1 <= budget {
+		return append(inline, entries...), nil, nil
+	}
+
+	// Otherwise reserve room for the CE pointer and overflow the rest.
+	overflowed := false
+	for _, e := range entries {
+		if !overflowed && inlineLen+len(e)+ceEntrySize+1 <= budget {
+			inline = append(inline, e)
+			inlineLen += len(e)
+		} else {
+			overflowed = true
+			cont = append(cont, e)
+		}
+	}
+	cont = append(cont, forcedCont...)
+
+	if inlineLen+ceEntrySize+1 > budget {
+		return nil, nil, fmt.Errorf("system use lead entries (%d bytes) exceed record budget (%d)", inlineLen, budget)
+	}
+	if entriesLen(cont) > consts.ISO9660_SECTOR_SIZE {
+		return nil, nil, fmt.Errorf("continuation area chunk (%d bytes) exceeds one sector", entriesLen(cont))
+	}
+	return inline, cont, nil
+}
+
+// dirPlan carries the record plans for one directory's extent: the "."
+// and ".." records plus one per child.
+type dirPlan struct {
+	dot      *recordPlan
+	dotdot   *recordPlan
+	children map[*tree.Node]*recordPlan
+}
+
+// packLayout holds the sector assignments produced by Pack.
+type packLayout struct {
+	pvdSector        uint32
+	terminatorSector uint32
+	pathTableLSector uint32
+	pathTableMSector uint32
+	pathTableSize    uint32
+	// Continuation area region for Rock Ridge data that does not fit
+	// inline (always at least one sector when Rock Ridge is enabled, for
+	// the ER entry).
+	contBaseSector uint32
+	contSectors    uint32
+	totalSectors   uint32
+	rockRidge      bool
+	// dirs is the breadth-first directory list; index+1 is each
+	// directory's path table number.
+	dirs []*tree.Node
+	// plans maps each directory to the record plans for its extent.
+	plans map[*tree.Node]*dirPlan
+	// identifiers maps every node to its on-disk identifier (path table
+	// and directory records must agree).
+	identifiers map[*tree.Node]string
+	// files is every regular file node in tree walk order.
+	files []*tree.Node
+}
+
+// rockRidgeWriteEnabled reports whether the rebuilt image should carry
+// Rock Ridge extensions: created images follow the create option
+// (default on); opened images preserve Rock Ridge when the source had it
+// and parsing was enabled.
+func (iso *ISO9660) rockRidgeWriteEnabled() bool {
+	if iso.createOptions != nil {
+		return iso.createOptions.RockRidgeEnabled
+	}
+	if iso.openOptions != nil {
+		return iso.openOptions.RockRidgeEnabled && iso.HasRockRidge()
+	}
+	return false
+}
+
+// rrAttributeEntries builds the RR/PX/TF (and SL for symlinks) entries
+// describing a node.
+func rrAttributeEntries(node *tree.Node) ([][]byte, error) {
+	mode := node.Mode()
+	if node.IsDir() {
+		mode |= fs.ModeDir
+	}
+	nlink := uint32(1)
+	if node.IsDir() {
+		nlink = 2
+		for _, c := range node.Children() {
+			if c.IsDir() {
+				nlink++
+			}
+		}
+	}
+
+	var rrFlags byte = 0x01 | 0x80 // PX + TF
+	var entries [][]byte
+	entries = append(entries, extensions.BuildPX(mode, nlink, node.UID(), node.GID()))
+
+	if node.IsSymlink() {
+		rrFlags |= 0x04
+		slEntries, err := extensions.BuildSL(node.SymlinkTarget())
+		if err != nil {
+			return nil, err
+		}
+		entries = append(entries, slEntries...)
+	}
+
+	tf, err := extensions.BuildTF(time.Time{}, recordingTime(node.ModTime()), time.Time{})
+	if err != nil {
+		return nil, err
+	}
+	entries = append(entries, tf)
+
+	return append([][]byte{extensions.BuildRR(rrFlags)}, entries...), nil
+}
+
+// rrChildEntries builds the full entry set for a child record: attributes
+// plus the NM entry carrying the POSIX name.
+func rrChildEntries(node *tree.Node) ([][]byte, error) {
+	entries, err := rrAttributeEntries(node)
+	if err != nil {
+		return nil, err
+	}
+	// The RR entry leads; splice NM's flag bit into it and append the NM
+	// entries after PX (order: RR, PX, [SL], NM, TF).
+	entries[0][4] |= 0x08
+	nm := extensions.BuildNM(node.Name())
+	tf := entries[len(entries)-1]
+	entries = append(entries[:len(entries)-1], nm...)
+	entries = append(entries, tf)
+	return entries, nil
+}
+
+// buildPlans computes identifiers and system use layouts for every record
+// in every directory extent. Location-independent: entry contents that
+// need locations (CE) are sized here and filled in after assignment.
+func buildPlans(dirs []*tree.Node, rockRidge bool) (map[*tree.Node]*dirPlan, map[*tree.Node]string, error) {
+	plans := make(map[*tree.Node]*dirPlan, len(dirs))
+	identifiers := make(map[*tree.Node]string)
+
+	for _, dir := range dirs {
+		dp := &dirPlan{children: map[*tree.Node]*recordPlan{}}
+		plans[dir] = dp
+
+		parent := dir.Parent()
+		if parent == nil {
+			parent = dir
+		}
+
+		dotBudget := maxDirectoryRecordLen - directoryRecordBaseLength(1)
+
+		if rockRidge {
+			// "." record: the root's carries SP first and defers the ER
+			// entry to a continuation area.
+			dotAttrs, err := rrAttributeEntries(dir)
+			if err != nil {
+				return nil, nil, err
+			}
+			var lead, forced [][]byte
+			if dir.IsRoot() {
+				lead = [][]byte{extensions.BuildSP(0)}
+				forced = [][]byte{extensions.BuildER()}
+			}
+			inline, cont, err := splitEntries(lead, dotAttrs, forced, dotBudget)
+			if err != nil {
+				return nil, nil, fmt.Errorf("planning %q: %w", dir.FullPath(), err)
+			}
+			dp.dot = &recordPlan{identifier: "\x00", inlineEntries: inline, contEntries: cont}
+
+			dotdotAttrs, err := rrAttributeEntries(parent)
+			if err != nil {
+				return nil, nil, err
+			}
+			inline, cont, err = splitEntries(nil, dotdotAttrs, nil, dotBudget)
+			if err != nil {
+				return nil, nil, fmt.Errorf("planning %q: %w", dir.FullPath(), err)
+			}
+			dp.dotdot = &recordPlan{identifier: "\x01", inlineEntries: inline, contEntries: cont}
+		} else {
+			dp.dot = &recordPlan{identifier: "\x00"}
+			dp.dotdot = &recordPlan{identifier: "\x01"}
+		}
+
+		children := dir.Children()
+		ids := assignIdentifiers(children, rockRidge)
+		for _, child := range children {
+			id := ids[child]
+			identifiers[child] = id
+			plan := &recordPlan{identifier: id}
+			if rockRidge {
+				entries, err := rrChildEntries(child)
+				if err != nil {
+					return nil, nil, err
+				}
+				budget := maxDirectoryRecordLen - directoryRecordBaseLength(len(id))
+				inline, cont, err := splitEntries(nil, entries, nil, budget)
+				if err != nil {
+					return nil, nil, fmt.Errorf("planning %q: %w", child.FullPath(), err)
+				}
+				plan.inlineEntries = inline
+				plan.contEntries = cont
+			}
+			dp.children[child] = plan
+		}
+	}
+
+	return plans, identifiers, nil
+}
+
+// eachPlan visits every record plan of a directory in extent order.
+func (dp *dirPlan) eachPlan(dir *tree.Node, fn func(target *tree.Node, plan *recordPlan) error) error {
+	parent := dir.Parent()
+	if parent == nil {
+		parent = dir
+	}
+	if err := fn(dir, dp.dot); err != nil {
+		return err
+	}
+	if err := fn(parent, dp.dotdot); err != nil {
+		return err
+	}
 	for _, child := range dir.Children() {
-		recLen := directoryRecordLength(len(isoFileIdentifier(child)))
+		if err := fn(child, dp.children[child]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// directoryExtentSize computes the byte size of a directory's extent from
+// its record plans, applying the rule that records never cross a sector
+// boundary, rounded up to a whole sector.
+func directoryExtentSize(dir *tree.Node, dp *dirPlan) uint32 {
+	offset := 0
+	_ = dp.eachPlan(dir, func(_ *tree.Node, plan *recordPlan) error {
+		recLen := plan.recordLen()
 		if offset%consts.ISO9660_SECTOR_SIZE+recLen > consts.ISO9660_SECTOR_SIZE {
 			offset = (offset/consts.ISO9660_SECTOR_SIZE + 1) * consts.ISO9660_SECTOR_SIZE
 		}
 		offset += recLen
-	}
+		return nil
+	})
 	return sectorsFor(uint32(offset)) * consts.ISO9660_SECTOR_SIZE
 }
 
 // pathTableSize computes the byte size of a path table over the given
-// breadth-first directory list. Each record is 8 bytes plus the identifier,
-// plus a pad byte when the identifier length is odd. Both the L and M
-// tables have the same size.
-func pathTableSize(dirs []*tree.Node) uint32 {
+// breadth-first directory list using the assigned identifiers. Both the L
+// and M tables have the same size.
+func pathTableSize(dirs []*tree.Node, identifiers map[*tree.Node]string) uint32 {
 	var size uint32
 	for _, dir := range dirs {
 		idLen := 1 // root identifier is a single 0x00 byte
 		if !dir.IsRoot() {
-			idLen = len(dir.Name())
+			idLen = len(identifiers[dir])
 		}
 		recLen := 8 + idLen
 		if idLen%2 != 0 {
@@ -77,30 +381,46 @@ func pathTableSize(dirs []*tree.Node) uint32 {
 	return size
 }
 
-// packLayout holds the sector assignments produced by Pack.
-type packLayout struct {
-	pvdSector        uint32
-	terminatorSector uint32
-	pathTableLSector uint32
-	pathTableMSector uint32
-	pathTableSize    uint32
-	totalSectors     uint32
-	// dirs is the breadth-first directory list; index+1 is each
-	// directory's path table number.
-	dirs []*tree.Node
-	// files is every file node in tree walk order.
-	files []*tree.Node
+// assignContinuationOffsets lays continuation chunks into the
+// continuation region: sequential, never crossing a sector boundary
+// (SUSP requires a continuation area to lie within one logical block).
+// Returns the number of sectors used.
+func assignContinuationOffsets(dirs []*tree.Node, plans map[*tree.Node]*dirPlan, baseSector uint32) uint32 {
+	block := uint32(0)
+	offset := uint32(0)
+	for _, dir := range dirs {
+		_ = plans[dir].eachPlan(dir, func(_ *tree.Node, plan *recordPlan) error {
+			chunk := uint32(plan.contLen())
+			if chunk == 0 {
+				return nil
+			}
+			if offset+chunk > consts.ISO9660_SECTOR_SIZE {
+				block++
+				offset = 0
+			}
+			plan.contBlock = baseSector + block
+			plan.contOffset = offset
+			offset += chunk
+			return nil
+		})
+	}
+	if offset == 0 && block == 0 {
+		return 0
+	}
+	return block + 1
 }
 
 // Pack assigns a sector location to every structure in the image: volume
-// descriptors, path tables, directory extents, and file extents. It updates
-// the PVD's size and location cross-references so a subsequent Save writes
-// a consistent image. The layout is:
+// descriptors, path tables, Rock Ridge continuation areas, directory
+// extents, and file extents. It updates the PVD's size and location
+// cross-references so a subsequent Save writes a consistent image. The
+// layout is:
 //
 //	sectors 0-15   system area
 //	sector  16     primary volume descriptor
 //	sector  17     volume descriptor set terminator
 //	next           L path table, then M path table
+//	next           Rock Ridge continuation area (when enabled)
 //	next           directory extents in breadth-first order (root first)
 //	next           file extents
 //
@@ -115,18 +435,28 @@ func (iso *ISO9660) Pack() error {
 		return fmt.Errorf("primary volume descriptor is missing")
 	}
 
+	rockRidge := iso.rockRidgeWriteEnabled()
+	dirs := iso.root.Directories()
+	plans, identifiers, err := buildPlans(dirs, rockRidge)
+	if err != nil {
+		return err
+	}
+
 	layout := &packLayout{
 		pvdSector:        consts.ISO9660_SYSTEM_AREA_SECTORS,
 		terminatorSector: consts.ISO9660_SYSTEM_AREA_SECTORS + 1,
-		dirs:             iso.root.Directories(),
+		rockRidge:        rockRidge,
+		dirs:             dirs,
+		plans:            plans,
+		identifiers:      identifiers,
 	}
 
 	// Directory extent sizes are independent of location, so they can be
 	// computed before sectors are assigned.
-	for _, dir := range layout.dirs {
-		dir.PackedSize = directoryExtentSize(dir)
+	for _, dir := range dirs {
+		dir.PackedSize = directoryExtentSize(dir, plans[dir])
 	}
-	layout.pathTableSize = pathTableSize(layout.dirs)
+	layout.pathTableSize = pathTableSize(dirs, identifiers)
 
 	next := layout.terminatorSector + 1
 	layout.pathTableLSector = next
@@ -134,13 +464,19 @@ func (iso *ISO9660) Pack() error {
 	layout.pathTableMSector = next
 	next += sectorsFor(layout.pathTableSize)
 
-	for _, dir := range layout.dirs {
+	// The continuation region's size is location-independent; assign its
+	// base here and lay chunks into it.
+	layout.contBaseSector = next
+	layout.contSectors = assignContinuationOffsets(dirs, plans, layout.contBaseSector)
+	next += layout.contSectors
+
+	for _, dir := range dirs {
 		dir.PackedLocation = next
 		next += sectorsFor(dir.PackedSize)
 	}
 
-	err := iso.root.Walk(func(node *tree.Node) error {
-		if node.IsDir() {
+	err = iso.root.Walk(func(node *tree.Node) error {
+		if node.IsDir() || node.IsSymlink() {
 			return nil
 		}
 		node.PackedLocation = next
@@ -175,8 +511,8 @@ func (iso *ISO9660) Pack() error {
 	}
 
 	// The root directory record embedded in the PVD points at the root
-	// extent.
-	pvd.RootDirectoryRecord = buildDirectoryRecord(iso.root, "\x00", iso.root)
+	// extent. It carries no system use data.
+	pvd.RootDirectoryRecord = buildDirectoryRecord(iso.root, "\x00", nil, iso.root)
 
 	iso.layout = layout
 	iso.isPacked = true
@@ -193,58 +529,72 @@ func recordingTime(t time.Time) time.Time {
 }
 
 // buildDirectoryRecord constructs the on-disk directory record describing
-// target, using the given identifier. The record's extent fields come from
-// target's packed location and size, so Pack must run first.
-func buildDirectoryRecord(target *tree.Node, identifier string, self *tree.Node) *directory.DirectoryRecord {
+// target, using the given identifier and system use field. The record's
+// extent fields come from target's packed location and size, so Pack must
+// run first.
+func buildDirectoryRecord(target *tree.Node, identifier string, systemUse []byte, timeSource *tree.Node) *directory.DirectoryRecord {
 	return &directory.DirectoryRecord{
 		LocationOfExtent:       target.PackedLocation,
 		DataLength:             target.PackedSize,
-		RecordingDateAndTime:   recordingTime(self.ModTime()),
+		RecordingDateAndTime:   recordingTime(timeSource.ModTime()),
 		FileFlags:              directory.FileFlags{Directory: target.IsDir()},
 		VolumeSequenceNumber:   1,
 		LengthOfFileIdentifier: uint8(len(identifier)),
 		FileIdentifier:         identifier,
+		SystemUse:              systemUse,
 	}
 }
 
 // marshalDirectoryExtent serializes a directory's extent: the "." and ".."
 // records followed by one record per child, zero-padding whenever a record
 // would cross a sector boundary. The result is exactly dir.PackedSize bytes.
-func marshalDirectoryExtent(dir *tree.Node) ([]byte, error) {
+func marshalDirectoryExtent(dir *tree.Node, dp *dirPlan) ([]byte, error) {
 	buf := make([]byte, dir.PackedSize)
 	offset := 0
 
-	parent := dir.Parent()
-	if parent == nil {
-		parent = dir // the root's ".." points at itself
-	}
-
-	records := []*directory.DirectoryRecord{
-		buildDirectoryRecord(dir, "\x00", dir),
-		buildDirectoryRecord(parent, "\x01", dir),
-	}
-	for _, child := range dir.Children() {
-		records = append(records, buildDirectoryRecord(child, isoFileIdentifier(child), child))
-	}
-
-	for _, rec := range records {
+	err := dp.eachPlan(dir, func(target *tree.Node, plan *recordPlan) error {
+		rec := buildDirectoryRecord(target, plan.identifier, plan.systemUse(), target)
 		data, err := rec.Marshal()
 		if err != nil {
-			return nil, fmt.Errorf("failed to marshal directory record %q in %q: %w",
-				rec.FileIdentifier, dir.FullPath(), err)
+			return fmt.Errorf("failed to marshal directory record %q in %q: %w",
+				plan.identifier, dir.FullPath(), err)
 		}
 		if offset%consts.ISO9660_SECTOR_SIZE+len(data) > consts.ISO9660_SECTOR_SIZE {
 			offset = (offset/consts.ISO9660_SECTOR_SIZE + 1) * consts.ISO9660_SECTOR_SIZE
 		}
 		if offset+len(data) > len(buf) {
-			return nil, fmt.Errorf("directory extent overflow in %q: computed size %d too small",
+			return fmt.Errorf("directory extent overflow in %q: computed size %d too small",
 				dir.FullPath(), dir.PackedSize)
 		}
 		copy(buf[offset:], data)
 		offset += len(data)
+		return nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	return buf, nil
+}
+
+// marshalContinuationArea serializes the Rock Ridge continuation region.
+// Returns nil when no continuation data exists.
+func (iso *ISO9660) marshalContinuationArea() []byte {
+	if iso.layout.contSectors == 0 {
+		return nil
+	}
+	buf := make([]byte, iso.layout.contSectors*consts.ISO9660_SECTOR_SIZE)
+	for _, dir := range iso.layout.dirs {
+		_ = iso.layout.plans[dir].eachPlan(dir, func(_ *tree.Node, plan *recordPlan) error {
+			if plan.contLen() == 0 {
+				return nil
+			}
+			start := (plan.contBlock-iso.layout.contBaseSector)*consts.ISO9660_SECTOR_SIZE + plan.contOffset
+			copy(buf[start:], plan.continuationData())
+			return nil
+		})
+	}
+	return buf
 }
 
 // buildPathTables produces the L (little-endian) and M (big-endian) path
@@ -267,7 +617,7 @@ func (iso *ISO9660) buildPathTables() (*pathtable.PathTable, *pathtable.PathTabl
 		identifier := "\x00"
 		parentNumber := uint16(1)
 		if !dir.IsRoot() {
-			identifier = dir.Name()
+			identifier = iso.layout.identifiers[dir]
 			parentNumber = dirNumber[dir.Parent()]
 		}
 		ptL.AddRecord(identifier, dir.PackedLocation, parentNumber)

--- a/pkg/iso9660/parser/parser.go
+++ b/pkg/iso9660/parser/parser.go
@@ -528,10 +528,28 @@ func (p *Parser) ReadDirectoryRecords(lba uint32, dataLength uint32, joliet bool
 		dr.ObjectSize = dr.DataLength
 
 		// **Parse Rock Ridge extensions if present**
-		var rr *extensions.RockRidgeExtensions
 		if len(dr.SystemUse) > 0 {
-			rr, err = extensions.UnmarshalRockRidge(dr.SystemUse)
-			if err == nil {
+			rr, rrErr := extensions.UnmarshalRockRidge(dr.SystemUse)
+			if rrErr == nil {
+				// Follow SUSP CE continuation areas, merging entries
+				// recorded outside the directory record. Bounded to
+				// guard against cyclic chains in corrupt images.
+				for hops := 0; rr.Continuation != nil && hops < 8; hops++ {
+					cont := rr.Continuation
+					if cont.Length == 0 || cont.Length > consts.ISO9660_SECTOR_SIZE {
+						break
+					}
+					contData := make([]byte, cont.Length)
+					contOffset := int64(cont.Block)*int64(sectorSize) + int64(cont.Offset)
+					if _, err := p.reader.ReadAt(contData, contOffset); err != nil {
+						p.logger.Debug("Failed to read Rock Ridge continuation area", "offset", contOffset, "error", err)
+						break
+					}
+					if err := rr.ParseInto(contData); err != nil {
+						p.logger.Debug("Failed to parse Rock Ridge continuation area", "offset", contOffset, "error", err)
+						break
+					}
+				}
 				dr.RockRidge = rr
 			}
 		}

--- a/pkg/iso9660/rockridge_test.go
+++ b/pkg/iso9660/rockridge_test.go
@@ -1,0 +1,219 @@
+package iso9660
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/bgrewell/iso-kit/pkg/iso9660/tree"
+	"github.com/bgrewell/iso-kit/pkg/option"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRockRidgeNamePreservation(t *testing.T) {
+	iso, err := Create("RRNAMES")
+	require.NoError(t, err)
+
+	// Names that ISO 9660 identifiers cannot represent.
+	longName := strings.Repeat("long-name-segment-", 5) + "tail.dat"
+	require.NoError(t, iso.AddFile("MixedCase File.txt", []byte("a")))
+	require.NoError(t, iso.AddFile(longName, []byte("b")))
+	require.NoError(t, iso.AddFile("dir with spaces/inner.txt", []byte("c")))
+	path := saveToTempFile(t, iso)
+
+	f, err := os.Open(path)
+	require.NoError(t, err)
+	defer f.Close()
+
+	reopened, err := Open(f)
+	require.NoError(t, err)
+
+	// POSIX names come back exactly via NM entries.
+	data, err := reopened.ReadFile("MixedCase File.txt")
+	require.NoError(t, err)
+	require.Equal(t, []byte("a"), data)
+
+	data, err = reopened.ReadFile(longName)
+	require.NoError(t, err)
+	require.Equal(t, []byte("b"), data)
+
+	data, err = reopened.ReadFile("dir with spaces/inner.txt")
+	require.NoError(t, err)
+	require.Equal(t, []byte("c"), data)
+}
+
+func TestRockRidgeIdentifiersAreMangled(t *testing.T) {
+	iso, err := Create("RRMANGLE")
+	require.NoError(t, err)
+	require.NoError(t, iso.AddFile("lower case.txt", []byte("x")))
+	path := saveToTempFile(t, iso)
+
+	f, err := os.Open(path)
+	require.NoError(t, err)
+	defer f.Close()
+
+	// With Rock Ridge parsing disabled, the raw ISO identifier shows:
+	// uppercase, invalid characters replaced.
+	reopened, err := Open(f, option.WithRockRidgeEnabled(false))
+	require.NoError(t, err)
+
+	files, err := reopened.ListFiles()
+	require.NoError(t, err)
+	require.Len(t, files, 1)
+	require.Equal(t, "LOWER_CASE.TXT;1", files[0].Name)
+}
+
+func TestRockRidgeModesAndTimes(t *testing.T) {
+	iso, err := Create("RRMETA")
+	require.NoError(t, err)
+
+	require.NoError(t, iso.AddFile("script.sh", []byte("#!/bin/sh\n")))
+	node := isoLookup(t, iso, "script.sh")
+	node.SetMode(0o755)
+	modTime := time.Date(2020, 6, 15, 12, 30, 45, 0, time.UTC)
+	node.SetModTime(modTime)
+	node.SetOwnership(1000, 1000)
+
+	path := saveToTempFile(t, iso)
+
+	f, err := os.Open(path)
+	require.NoError(t, err)
+	defer f.Close()
+
+	reopened, err := Open(f)
+	require.NoError(t, err)
+
+	files, err := reopened.ListFiles()
+	require.NoError(t, err)
+	require.Len(t, files, 1)
+	entry := files[0]
+
+	require.Equal(t, os.FileMode(0o755), entry.Mode.Perm())
+	require.NotNil(t, entry.UID)
+	require.Equal(t, uint32(1000), *entry.UID)
+	require.NotNil(t, entry.GID)
+	require.Equal(t, uint32(1000), *entry.GID)
+	require.True(t, entry.ModTime.Equal(modTime), "mod time mismatch: got %v want %v", entry.ModTime, modTime)
+}
+
+func TestRockRidgeSymlink(t *testing.T) {
+	iso, err := Create("RRLINK")
+	require.NoError(t, err)
+
+	require.NoError(t, iso.AddFile("target.txt", []byte("data")))
+	_, err = iso.root.AddSymlink("link.txt", "target.txt")
+	require.NoError(t, err)
+	_, err = iso.root.AddSymlink("abs-link", "/usr/share/doc")
+	require.NoError(t, err)
+	_, err = iso.root.AddSymlink("rel-link", "../up/../over/./there")
+	require.NoError(t, err)
+	iso.markDirty()
+
+	path := saveToTempFile(t, iso)
+
+	f, err := os.Open(path)
+	require.NoError(t, err)
+	defer f.Close()
+
+	reopened, err := Open(f)
+	require.NoError(t, err)
+
+	for name, want := range map[string]string{
+		"link.txt": "target.txt",
+		"abs-link": "/usr/share/doc",
+		"rel-link": "../up/../over/./there",
+	} {
+		node := reopened.root.Lookup(name)
+		require.NotNil(t, node, "symlink %s not found", name)
+		require.True(t, node.IsSymlink(), "%s should be a symlink", name)
+		require.Equal(t, want, node.SymlinkTarget(), "target mismatch for %s", name)
+	}
+}
+
+func TestRockRidgeSurvivesModifyRoundTrip(t *testing.T) {
+	iso, err := Create("RRMOD")
+	require.NoError(t, err)
+	require.NoError(t, iso.AddFile("Original Name.txt", []byte("one")))
+	basePath := saveToTempFile(t, iso)
+
+	base, err := os.Open(basePath)
+	require.NoError(t, err)
+	defer base.Close()
+
+	opened, err := Open(base)
+	require.NoError(t, err)
+	require.NoError(t, opened.AddFile("Another File.txt", []byte("two")))
+	modPath := saveToTempFile(t, opened)
+
+	mod, err := os.Open(modPath)
+	require.NoError(t, err)
+	defer mod.Close()
+
+	final, err := Open(mod)
+	require.NoError(t, err)
+
+	data, err := final.ReadFile("Original Name.txt")
+	require.NoError(t, err)
+	require.Equal(t, []byte("one"), data)
+	data, err = final.ReadFile("Another File.txt")
+	require.NoError(t, err)
+	require.Equal(t, []byte("two"), data)
+}
+
+func TestRockRidgeDisabled(t *testing.T) {
+	iso, err := Create("NORR", option.WithCreateRockRidgeEnabled(false))
+	require.NoError(t, err)
+	require.NoError(t, iso.AddFile("PLAIN.TXT", []byte("plain")))
+	path := saveToTempFile(t, iso)
+
+	f, err := os.Open(path)
+	require.NoError(t, err)
+	defer f.Close()
+
+	reopened, err := Open(f)
+	require.NoError(t, err)
+	require.False(t, reopened.HasRockRidge())
+
+	data, err := reopened.ReadFile("PLAIN.TXT")
+	require.NoError(t, err)
+	require.Equal(t, []byte("plain"), data)
+}
+
+// TestRockRidgeInteropXorriso verifies that xorriso recognizes the Rock
+// Ridge extensions and reports the POSIX names and modes.
+func TestRockRidgeInteropXorriso(t *testing.T) {
+	xorriso, err := exec.LookPath("xorriso")
+	if err != nil {
+		t.Skip("xorriso not available")
+	}
+
+	iso, err := Create("RRINTEROP")
+	require.NoError(t, err)
+	require.NoError(t, iso.AddFile("Mixed Case Name.txt", []byte("rr interop\n")))
+	node := isoLookup(t, iso, "Mixed Case Name.txt")
+	node.SetMode(0o640)
+	_, err = iso.root.AddSymlink("the-link", "Mixed Case Name.txt")
+	require.NoError(t, err)
+	iso.markDirty()
+	path := saveToTempFile(t, iso)
+
+	out, err := exec.Command(xorriso, "-indev", path, "-find", "/", "-exec", "lsdl").CombinedOutput()
+	require.NoError(t, err, "xorriso failed: %s", out)
+	text := string(out)
+
+	// Rock Ridge recognized: POSIX name and symlink reported.
+	require.Contains(t, text, "Mixed Case Name.txt")
+	require.Contains(t, text, "the-link")
+	require.Contains(t, text, "-rw-r-----", "expected 0640 mode from PX entry")
+	require.Contains(t, text, "->", "expected symlink arrow in listing")
+}
+
+// isoLookup returns the tree node at path, failing the test if missing.
+func isoLookup(t *testing.T, iso *ISO9660, path string) *tree.Node {
+	t.Helper()
+	node := iso.root.Lookup(path)
+	require.NotNil(t, node, "path not found in tree: %s", path)
+	return node
+}

--- a/pkg/iso9660/tree/tree.go
+++ b/pkg/iso9660/tree/tree.go
@@ -38,6 +38,11 @@ type Node struct {
 
 	mode    os.FileMode
 	modTime time.Time
+	uid     uint32
+	gid     uint32
+
+	// Symlink target; non-empty only for symbolic link nodes.
+	symlinkTarget string
 
 	// PackedLocation and PackedSize are assigned by the layout engine
 	// before writing. PackedSize for a directory is the extent size in
@@ -82,6 +87,21 @@ func (n *Node) SetMode(mode os.FileMode) { n.mode = mode }
 
 // SetModTime sets the modification time.
 func (n *Node) SetModTime(t time.Time) { n.modTime = t }
+
+// UID returns the POSIX user ID (0 unless set).
+func (n *Node) UID() uint32 { return n.uid }
+
+// GID returns the POSIX group ID (0 unless set).
+func (n *Node) GID() uint32 { return n.gid }
+
+// SetOwnership sets the POSIX user and group IDs.
+func (n *Node) SetOwnership(uid, gid uint32) { n.uid, n.gid = uid, gid }
+
+// IsSymlink reports whether the node is a symbolic link.
+func (n *Node) IsSymlink() bool { return n.symlinkTarget != "" }
+
+// SymlinkTarget returns the symlink target path, or "" for non-links.
+func (n *Node) SymlinkTarget() string { return n.symlinkTarget }
 
 // IsPending reports whether the node's content lives in memory rather than
 // in a backing image.
@@ -228,6 +248,37 @@ func (n *Node) AddFile(path string, data []byte) (*Node, error) {
 		size:    uint32(len(data)),
 		mode:    0o644,
 		modTime: time.Now(),
+	}
+	dir.children[name] = node
+	return node, nil
+}
+
+// AddSymlink inserts a symbolic link node at the given path pointing at
+// target, creating parent directories as needed. The link itself carries
+// no content; the target is recorded verbatim (Rock Ridge SL entry on
+// write).
+func (n *Node) AddSymlink(path, target string) (*Node, error) {
+	if target == "" {
+		return nil, fmt.Errorf("symlink target is empty")
+	}
+	parts := splitPath(path)
+	if len(parts) == 0 {
+		return nil, fmt.Errorf("symlink path is empty")
+	}
+	name := StripVersion(parts[len(parts)-1])
+	dir, err := n.mkdirs(parts[:len(parts)-1])
+	if err != nil {
+		return nil, err
+	}
+	if existing := dir.children[name]; existing != nil && existing.isDir {
+		return nil, fmt.Errorf("path %q is a directory", existing.FullPath())
+	}
+	node := &Node{
+		name:          name,
+		parent:        dir,
+		symlinkTarget: target,
+		mode:          os.ModeSymlink | 0o777,
+		modTime:       time.Now(),
 	}
 	dir.children[name] = node
 	return node, nil

--- a/pkg/option/create.go
+++ b/pkg/option/create.go
@@ -15,7 +15,10 @@ type CreateOptions struct {
 	Preparer      string
 	RootDir       string
 	JolietEnabled bool
-	Logger        *logging.Logger
+	// RockRidgeEnabled controls whether created images carry Rock Ridge
+	// (POSIX metadata) extensions. Defaults to true.
+	RockRidgeEnabled bool
+	Logger           *logging.Logger
 }
 
 type CreateOption func(*CreateOptions)
@@ -41,6 +44,12 @@ func WithRootDir(rootDir string) CreateOption {
 func WithJolietEnabled(jolietEnabled bool) CreateOption {
 	return func(o *CreateOptions) {
 		o.JolietEnabled = jolietEnabled
+	}
+}
+
+func WithCreateRockRidgeEnabled(rockRidgeEnabled bool) CreateOption {
+	return func(o *CreateOptions) {
+		o.RockRidgeEnabled = rockRidgeEnabled
 	}
 }
 


### PR DESCRIPTION
## Summary

First slice of P2 (extensions write support): created and modified images now carry **Rock Ridge POSIX metadata** — long mixed-case names, permissions, ownership, timestamps, and symlinks — verified against xorriso.

### New: SUSP framework (`pkg/iso9660/extensions/susp.go`)
Correct builders for the System Use Sharing Protocol entries (SP, CE, ER, ST, RR) and all RRIP entries: PX (36-byte both-endian form), PN, NM/SL with multi-entry continuation, TF (7-byte recording format), CL/PL, RE. The previous `MarshalRockRidge` — self-acknowledged broken, with wrong lengths, single-endian fields, and missing SL component records — now delegates to these builders.

### Fixed: Rock Ridge unmarshal
- TF: honors flag-bit ordering and the long-form (17-byte) format; previously read 4 bytes as a unix timestamp out of a 7-byte ISO field
- SL: decodes component records (root/current/parent flags, per-component lengths) instead of treating the payload as a raw string
- NM: continuation entries append instead of overwrite
- Added parsing for PN, CL, PL, RE, SF, and CE
- The directory parser now follows CE continuation chains (hop-bounded against cycles in corrupt images)

### Write pipeline integration
The layout engine plans each directory record's system-use field:
- SP leads the root "." record; the ER entry goes in a dedicated continuation region (at 237 bytes it never fits inline); CE pointers link them
- Every record (including "."/"..") carries RR/PX/TF; children carry NM; symlinks carry SL
- Entries exceeding a record's 255-byte budget overflow to the continuation region — continuation chunks never cross a sector boundary per SUSP
- ISO identifiers are mangled (uppercase d-characters, 31-char cap, deterministic `~N` collision dedupe) while POSIX names travel in NM
- The tree models symlinks and uid/gid; `AddLocalDirectory` imports symlinks; `Open` rebuilds symlink nodes from parsed SL data

### Behavior
- Created images write Rock Ridge **by default**; `WithCreateRockRidgeEnabled(false)` opts out
- Opened images preserve Rock Ridge only when the source had it — plain-ISO round-trips stay byte-exact

## Test plan
- Name preservation: mixed case, spaces, 98-char names round-trip via NM
- Identifier mangling verified by reopening with RR parsing disabled
- Mode (0755), uid/gid (1000/1000), and mtime round-trips via PX/TF
- Symlink round-trips: absolute, relative, and dot-component targets via SL
- Modify-and-save preserves RR metadata
- xorriso interop: independent implementation reports our POSIX names, PX modes (`-rw-r-----` from 0640), and symlink targets
- Full suite green: `go build`, `go vet`, `go test ./...`