### PR TITLE
Add Joliet write support with UCS-2 hierarchy

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -88,9 +88,9 @@ Goal: create and modify ISOs. Largest and most architecturally significant phase
   - Zero-pads at sector boundaries (records never cross boundaries)
 - [x] Implement path table builder from directory tree (`pack.go: buildPathTables`)
   - Breadth-first walk, sequential parent numbers, L-type and M-type output
-- [ ] Promote SVD numeric fields from raw byte arrays to typed values
-  - VolumeSpaceSize, VolumeSetSize, etc. — match PVD pattern
-  - Required for Pack() to update SVD programmatically (needed for Joliet write, P2)
+- [x] Promote SVD numeric fields from raw byte arrays to typed values
+  - VolumeSpaceSize (uint32), VolumeSetSize/VolumeSequenceNumber/
+    LogicalBlockSize (uint16), both-byte-order encoding matching the PVD
 - [x] Implement `Pack()` — the sector layout engine
   - Assigns sector locations: PVD, terminator, path tables, directory extents
     (breadth-first), file data
@@ -106,8 +106,9 @@ Goal: create and modify ISOs. Largest and most architecturally significant phase
     created/modified images
   - Pending files written from memory, existing files streamed from isoReader
     (relocation-safe)
-- [ ] Fix Joliet directory record marshal (UCS-2 re-encoding)
-  - When `dr.Joliet` is true, encode FileIdentifier as UCS-2 (with P2 Joliet work)
+- [x] Fix Joliet directory record marshal (UCS-2 re-encoding)
+  - Identifiers are pre-encoded to UCS-2 in the layout engine's Joliet
+    record plans; the record marshal writes them byte-exact
 - [ ] Add `VolumeDescriptorSet` methods (WriteTo, Validate)
 - [ ] Implement `VolumePartitionDescriptor` Marshal/Unmarshal
 - [x] End-to-end Create→AddFile→Save→Open verification test
@@ -139,8 +140,13 @@ Goal: proper extension support with spec-compliant serialization.
     (`WithCreateRockRidgeEnabled(false)` to disable); opened images keep RR
     iff the source had it
   - Verified with xorriso: POSIX names, PX modes, and symlinks recognized
-- [ ] Complete Joliet write support
-  - Separate UCS-2 directory tree, separate path tables, 64-char filename validation
+- [x] Complete Joliet write support
+  - SVD written at sector 17; separate UCS-2 directory extents and path
+    tables sharing file data with the primary hierarchy; 64-unit name
+    sanitization/truncation with ~N dedupe
+  - Created images opt in with `WithJolietEnabled(true)`; opened images
+    preserve Joliet when the source had it; verified with xorriso
+    (`-read_fs norock` shows the Joliet tree with Unicode names)
 - [ ] Fix El Torito entry field offsets to match specification
   - Byte 0 = Boot Indicator, byte 1 = Boot Media Type, bytes 2-3 = Load Segment
 - [ ] Fix El Torito marshal for multi-boot catalogs with section headers

--- a/pkg/iso9660/descriptor/supplementary.go
+++ b/pkg/iso9660/descriptor/supplementary.go
@@ -174,9 +174,10 @@ type SupplementaryVolumeDescriptorBody struct {
 	VolumeIdentifier string `json:"volume_identifier"`
 	// Unused Field is a block of unused bytes from BP73-80 and should contain only 0x00 bytes
 	UnusedField1 [8]byte `json:"unused_field_1"`
-	// Volume Space Size is a 8 byte field that the spec doesn't seem to address how it's used. (Table 6 of ECMA-199
-	// incorrectly lists this as 32 bytes)
-	VolumeSpaceSize [8]byte `json:"volume_space_size"`
+	// Volume Space Size specifies the number of logical blocks in which the
+	// Volume Space of the volume is recorded.
+	//  | Encoding: BothByteOrder
+	VolumeSpaceSize uint32 `json:"volume_space_size"`
 	// Escape Sequences specifies one or more escape sequences according to ISO 2022 that designate the G0 graphic
 	// character set and, optionally, the G1 graphic character set to be used in an 8-bit environment according to
 	// ISO 2022 to interpret descriptor fields related to the Directory Hierarchy identified by this Volume Descriptor
@@ -189,15 +190,16 @@ type SupplementaryVolumeDescriptorBody struct {
 	// set of a1-characters is identical with the set of a-characters and that the set of d1-characters is identical
 	// with the set of d-characters. In this case both sets are coded according to ECMA-6.
 	EscapeSequences [32]byte `json:"escape_sequences"`
-	// Volume Set Size is a numerical value that is 4 bytes in size and is not addressed with regard to usage in the
-	// spec. Note: look into more, probably a uint16 stored as both little and big endian.
-	VolumeSetSize [4]byte `json:"volume_set_size"`
-	// Volume Sequence Number is a numerical value that is 4 bytes in size and is not addressed with regard to usage in
-	// the spec. Note: look into more, probably a uint16 stored as both little and big endian.
-	VolumeSequenceNumber [4]byte `json:"volume_sequence_number"`
-	// Logical Block Size is a numerical value that is 4 bytes in size and is not addressed with regard to usage in the
-	// spec. Note: look into more, probably a uint16 stored as both little and big endian.
-	LogicalBlockSize [4]byte `json:"logical_block_size"`
+	// Volume Set Size specifies the assigned Volume Set size of the volume.
+	//  | Encoding: BothByteOrder
+	VolumeSetSize uint16 `json:"volume_set_size"`
+	// Volume Sequence Number specifies the ordinal number of the volume in
+	// the Volume Set.
+	//  | Encoding: BothByteOrder
+	VolumeSequenceNumber uint16 `json:"volume_sequence_number"`
+	// Logical Block Size specifies the size in bytes of a logical block.
+	//  | Encoding: BothByteOrder
+	LogicalBlockSize uint16 `json:"logical_block_size"`
 	// Path Table Size specifies the length in bytes of a recorded occurrence of the Path Table identified by this
 	// Volume Descriptor.
 	//  | Encoding: BothByteOrder
@@ -353,24 +355,28 @@ func (svdb *SupplementaryVolumeDescriptorBody) Marshal() ([]byte, error) {
 	copy(data[offset:offset+8], svdb.UnusedField1[:])
 	offset += 8
 
-	// 5. volumeSpaceSize: 8 bytes.
-	copy(data[offset:offset+8], svdb.VolumeSpaceSize[:])
+	// 5. volumeSpaceSize: 8 bytes (both-byte orders for uint32).
+	vssBytes := encoding.MarshalBothByteOrders32(svdb.VolumeSpaceSize)
+	copy(data[offset:offset+8], vssBytes[:])
 	offset += 8
 
 	// 6. EscapeSequences: 32 bytes.
 	copy(data[offset:offset+32], svdb.EscapeSequences[:])
 	offset += 32
 
-	// 7. volumeSetSize: 4 bytes
-	copy(data[offset:offset+4], svdb.VolumeSetSize[:])
+	// 7. volumeSetSize: 4 bytes (both-byte orders for uint16).
+	vsBytes := encoding.MarshalBothByteOrders16(svdb.VolumeSetSize)
+	copy(data[offset:offset+4], vsBytes[:])
 	offset += 4
 
-	// 8. volumeSequenceNumber: 4 bytes
-	copy(data[offset:offset+4], svdb.VolumeSequenceNumber[:])
+	// 8. volumeSequenceNumber: 4 bytes (both-byte orders for uint16).
+	vsnBytes := encoding.MarshalBothByteOrders16(svdb.VolumeSequenceNumber)
+	copy(data[offset:offset+4], vsnBytes[:])
 	offset += 4
 
-	// 9. logicalBlockSize: 4 bytes
-	copy(data[offset:offset+4], svdb.LogicalBlockSize[:])
+	// 9. logicalBlockSize: 4 bytes (both-byte orders for uint16).
+	lbsBytes := encoding.MarshalBothByteOrders16(svdb.LogicalBlockSize)
+	copy(data[offset:offset+4], lbsBytes[:])
 	offset += 4
 
 	// 10. pathTableSize: 8 bytes (both-byte orders for uint32).
@@ -556,23 +562,47 @@ func (svdb *SupplementaryVolumeDescriptorBody) Unmarshal(data []byte) error {
 	copy(svdb.UnusedField1[:], data[offset:offset+8])
 	offset += 8
 
-	// 5. Volume Space Size: 8 bytes
-	copy(svdb.VolumeSpaceSize[:], data[offset:offset+8])
+	// 5. Volume Space Size: 8 bytes (both-byte orders for uint32)
+	var vssBytes [8]byte
+	copy(vssBytes[:], data[offset:offset+8])
+	volumeSpaceSize, err := encoding.UnmarshalUint32LSBMSB(vssBytes)
+	if err != nil {
+		return fmt.Errorf("failed to unmarshal volumeSpaceSize: %w", err)
+	}
+	svdb.VolumeSpaceSize = volumeSpaceSize
 	offset += 8
 
 	// 6. Skip over the Escape Sequences: 32 bytes (Used to determine Joliet) since it was read above
 	offset += 32
 
-	// 7. Volume Set Size: 4 bytes
-	copy(svdb.VolumeSetSize[:], data[offset:offset+4])
+	// 7. Volume Set Size: 4 bytes (both-byte orders for uint16)
+	var vsBytes [4]byte
+	copy(vsBytes[:], data[offset:offset+4])
+	volumeSetSize, err := encoding.UnmarshalUint16LSBMSB(vsBytes)
+	if err != nil {
+		return fmt.Errorf("failed to unmarshal volumeSetSize: %w", err)
+	}
+	svdb.VolumeSetSize = volumeSetSize
 	offset += 4
 
-	// 8. Volume Sequence Number: 4 bytes
-	copy(svdb.VolumeSequenceNumber[:], data[offset:offset+4])
+	// 8. Volume Sequence Number: 4 bytes (both-byte orders for uint16)
+	var vsnBytes [4]byte
+	copy(vsnBytes[:], data[offset:offset+4])
+	volumeSequenceNumber, err := encoding.UnmarshalUint16LSBMSB(vsnBytes)
+	if err != nil {
+		return fmt.Errorf("failed to unmarshal volumeSequenceNumber: %w", err)
+	}
+	svdb.VolumeSequenceNumber = volumeSequenceNumber
 	offset += 4
 
-	// 9. Logical Block Size: 4 bytes
-	copy(svdb.LogicalBlockSize[:], data[offset:offset+4])
+	// 9. Logical Block Size: 4 bytes (both-byte orders for uint16)
+	var lbsBytes [4]byte
+	copy(lbsBytes[:], data[offset:offset+4])
+	logicalBlockSize, err := encoding.UnmarshalUint16LSBMSB(lbsBytes)
+	if err != nil {
+		return fmt.Errorf("failed to unmarshal logicalBlockSize: %w", err)
+	}
+	svdb.LogicalBlockSize = logicalBlockSize
 	offset += 4
 
 	// 10. Path Table Size: 8 bytes

--- a/pkg/iso9660/iso9660.go
+++ b/pkg/iso9660/iso9660.go
@@ -258,10 +258,6 @@ func Create(name string, opts ...option.CreateOption) (*ISO9660, error) {
 		isPacked: false,
 	}
 
-	if createOptions.JolietEnabled {
-		iso.logger.Info("WARNING: Joliet output is not yet supported; the image will be written without a supplementary volume descriptor")
-	}
-
 	if createOptions.RootDir != "" {
 		if err := iso.AddLocalDirectory(createOptions.RootDir, "/"); err != nil {
 			return nil, err
@@ -998,9 +994,6 @@ func (iso *ISO9660) saveRebuild(writer io.WriterAt) error {
 	if iso.volumeDescriptorSet.Boot != nil || iso.elTorito != nil {
 		iso.logger.Info("WARNING: El Torito boot structures are not yet supported in rebuilt images; the output will not be bootable")
 	}
-	if len(iso.volumeDescriptorSet.Supplementary) > 0 {
-		iso.logger.Info("WARNING: Joliet output is not yet supported; the supplementary volume descriptor is dropped from the rebuilt image")
-	}
 
 	if err := iso.Pack(); err != nil {
 		return fmt.Errorf("failed to pack image: %w", err)
@@ -1018,6 +1011,17 @@ func (iso *ISO9660) saveRebuild(writer io.WriterAt) error {
 	}
 	if _, err := writer.WriteAt(pvdBytes, int64(iso.layout.pvdSector)*consts.ISO9660_SECTOR_SIZE); err != nil {
 		return fmt.Errorf("failed to write primary volume descriptor: %w", err)
+	}
+
+	// 2b. Supplementary (Joliet) volume descriptor.
+	if iso.layout.joliet {
+		svdBytes, err := iso.jolietSVD().Marshal()
+		if err != nil {
+			return fmt.Errorf("failed to marshal supplementary volume descriptor: %w", err)
+		}
+		if _, err := writer.WriteAt(svdBytes, int64(iso.layout.svdSector)*consts.ISO9660_SECTOR_SIZE); err != nil {
+			return fmt.Errorf("failed to write supplementary volume descriptor: %w", err)
+		}
 	}
 
 	// 3. Volume descriptor set terminator.
@@ -1054,6 +1058,26 @@ func (iso *ISO9660) saveRebuild(writer io.WriterAt) error {
 	}
 	iso.pathTables = []*pathtable.PathTable{ptL, ptM}
 
+	// 4b. Joliet path tables.
+	if iso.layout.joliet {
+		jptL, jptM, err := iso.buildJolietPathTables()
+		if err != nil {
+			return err
+		}
+		for _, pt := range []*pathtable.PathTable{jptL, jptM} {
+			data, err := pt.Marshal()
+			if err != nil {
+				return fmt.Errorf("failed to marshal Joliet path table: %w", err)
+			}
+			padded := make([]byte, sectorsFor(uint32(len(data)))*consts.ISO9660_SECTOR_SIZE)
+			copy(padded, data)
+			if _, err := writer.WriteAt(padded, pt.Offset()); err != nil {
+				return fmt.Errorf("failed to write Joliet path table: %w", err)
+			}
+		}
+		iso.pathTables = append(iso.pathTables, jptL, jptM)
+	}
+
 	// 5. Rock Ridge continuation area (ER entry and overflow), if any.
 	if contData := iso.marshalContinuationArea(); contData != nil {
 		contOffset := int64(iso.layout.contBaseSector) * consts.ISO9660_SECTOR_SIZE
@@ -1062,14 +1086,27 @@ func (iso *ISO9660) saveRebuild(writer io.WriterAt) error {
 		}
 	}
 
-	// 6. Directory extents in breadth-first order.
+	// 6. Directory extents in breadth-first order: primary hierarchy,
+	// then the Joliet hierarchy.
 	for _, dir := range iso.layout.dirs {
-		data, err := marshalDirectoryExtent(dir, iso.layout.plans[dir])
+		data, err := marshalDirectoryExtent(dir, iso.layout.plans[dir], dir.PackedSize, iso.layout.primaryRef)
 		if err != nil {
 			return err
 		}
 		if _, err := writer.WriteAt(data, int64(dir.PackedLocation)*consts.ISO9660_SECTOR_SIZE); err != nil {
 			return fmt.Errorf("failed to write directory extent for %q: %w", dir.FullPath(), err)
+		}
+	}
+	if iso.layout.joliet {
+		for _, dir := range iso.layout.dirs {
+			data, err := marshalDirectoryExtent(dir, iso.layout.jolietPlans[dir], iso.layout.jolietDirSize[dir], iso.layout.jolietRef)
+			if err != nil {
+				return err
+			}
+			location := int64(iso.layout.jolietDirLocation[dir]) * consts.ISO9660_SECTOR_SIZE
+			if _, err := writer.WriteAt(data, location); err != nil {
+				return fmt.Errorf("failed to write Joliet directory extent for %q: %w", dir.FullPath(), err)
+			}
 		}
 	}
 

--- a/pkg/iso9660/joliet_test.go
+++ b/pkg/iso9660/joliet_test.go
@@ -1,0 +1,171 @@
+package iso9660
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/bgrewell/iso-kit/pkg/option"
+	"github.com/stretchr/testify/require"
+)
+
+func createJolietImage(t *testing.T) string {
+	t.Helper()
+	iso, err := Create("JOLIETVOL", option.WithJolietEnabled(true))
+	require.NoError(t, err)
+	require.NoError(t, iso.AddFile("Mixed Case Document.txt", []byte("joliet content\n")))
+	require.NoError(t, iso.AddFile("Ünïcödé Nämé.txt", []byte("unicode\n")))
+	require.NoError(t, iso.AddFile("nested/Deep Dir Name/file.bin", []byte{1, 2, 3}))
+	return saveToTempFile(t, iso)
+}
+
+func TestJolietCreateAndReopenPrimary(t *testing.T) {
+	path := createJolietImage(t)
+
+	f, err := os.Open(path)
+	require.NoError(t, err)
+	defer f.Close()
+
+	// Default open reads the primary (Rock Ridge) hierarchy; names come
+	// back exactly and the image reports Joliet present.
+	reopened, err := Open(f)
+	require.NoError(t, err)
+	require.True(t, reopened.HasJoliet(), "reopened image should report Joliet")
+
+	data, err := reopened.ReadFile("Mixed Case Document.txt")
+	require.NoError(t, err)
+	require.Equal(t, []byte("joliet content\n"), data)
+
+	data, err = reopened.ReadFile("nested/Deep Dir Name/file.bin")
+	require.NoError(t, err)
+	require.Equal(t, []byte{1, 2, 3}, data)
+}
+
+func TestJolietCreateAndReopenJolietHierarchy(t *testing.T) {
+	path := createJolietImage(t)
+
+	f, err := os.Open(path)
+	require.NoError(t, err)
+	defer f.Close()
+
+	// PreferJoliet walks the SVD hierarchy: UCS-2 names decode back to
+	// the original strings, and file content resolves through the shared
+	// extents.
+	reopened, err := Open(f, option.WithPreferJoliet(true))
+	require.NoError(t, err)
+	require.Equal(t, "JOLIETVOL", reopened.GetVolumeID())
+
+	data, err := reopened.ReadFile("Mixed Case Document.txt")
+	require.NoError(t, err)
+	require.Equal(t, []byte("joliet content\n"), data)
+
+	data, err = reopened.ReadFile("Ünïcödé Nämé.txt")
+	require.NoError(t, err)
+	require.Equal(t, []byte("unicode\n"), data)
+
+	data, err = reopened.ReadFile("nested/Deep Dir Name/file.bin")
+	require.NoError(t, err)
+	require.Equal(t, []byte{1, 2, 3}, data)
+}
+
+func TestJolietLongNameTruncation(t *testing.T) {
+	iso, err := Create("JLONG", option.WithJolietEnabled(true))
+	require.NoError(t, err)
+
+	// 80 characters: legal in Rock Ridge, truncated to 64 in Joliet.
+	longName := strings.Repeat("abcdefgh", 10) + ".txt"
+	require.NoError(t, iso.AddFile(longName, []byte("long")))
+	path := saveToTempFile(t, iso)
+
+	f, err := os.Open(path)
+	require.NoError(t, err)
+	defer f.Close()
+
+	reopened, err := Open(f, option.WithPreferJoliet(true))
+	require.NoError(t, err)
+
+	files, err := reopened.ListFiles()
+	require.NoError(t, err)
+	require.Len(t, files, 1)
+	// 64 UTF-16 units maximum (the version suffix rides on top).
+	name := strings.TrimSuffix(files[0].Name, ";1")
+	require.LessOrEqual(t, len([]rune(name)), 64)
+	require.True(t, strings.HasPrefix(name, "abcdefgh"), "truncated name should preserve the prefix, got %q", name)
+
+	// The Rock Ridge hierarchy still has the full name.
+	rrOpen, err := os.Open(path)
+	require.NoError(t, err)
+	defer rrOpen.Close()
+	viaRR, err := Open(rrOpen)
+	require.NoError(t, err)
+	data, err := viaRR.ReadFile(longName)
+	require.NoError(t, err)
+	require.Equal(t, []byte("long"), data)
+}
+
+func TestJolietPreservedOnModify(t *testing.T) {
+	basePath := createJolietImage(t)
+
+	base, err := os.Open(basePath)
+	require.NoError(t, err)
+	defer base.Close()
+
+	opened, err := Open(base)
+	require.NoError(t, err)
+	require.NoError(t, opened.AddFile("Added Later.txt", []byte("later")))
+	modPath := saveToTempFile(t, opened)
+
+	mod, err := os.Open(modPath)
+	require.NoError(t, err)
+	defer mod.Close()
+
+	// The rebuilt image keeps its Joliet hierarchy, including the new file.
+	final, err := Open(mod, option.WithPreferJoliet(true))
+	require.NoError(t, err)
+
+	data, err := final.ReadFile("Added Later.txt")
+	require.NoError(t, err)
+	require.Equal(t, []byte("later"), data)
+
+	data, err = final.ReadFile("Mixed Case Document.txt")
+	require.NoError(t, err)
+	require.Equal(t, []byte("joliet content\n"), data)
+}
+
+func TestNoJolietByDefault(t *testing.T) {
+	iso, err := Create("NOJOLIET")
+	require.NoError(t, err)
+	require.NoError(t, iso.AddFile("plain.txt", []byte("x")))
+	path := saveToTempFile(t, iso)
+
+	f, err := os.Open(path)
+	require.NoError(t, err)
+	defer f.Close()
+
+	reopened, err := Open(f)
+	require.NoError(t, err)
+	require.False(t, reopened.HasJoliet())
+}
+
+// TestJolietInteropXorriso verifies that xorriso sees the Joliet
+// hierarchy in a created image.
+func TestJolietInteropXorriso(t *testing.T) {
+	xorriso, err := exec.LookPath("xorriso")
+	if err != nil {
+		t.Skip("xorriso not available")
+	}
+
+	path := createJolietImage(t)
+
+	// Disable Rock Ridge reading so xorriso falls back to the Joliet
+	// tree (Rock Ridge takes priority otherwise).
+	out, err := exec.Command(xorriso, "-read_fs", "norock", "-indev", path,
+		"-find", "/", "-exec", "lsdl").CombinedOutput()
+	require.NoError(t, err, "xorriso failed: %s", out)
+	text := string(out)
+
+	require.Contains(t, text, "Mixed Case Document.txt")
+	require.Contains(t, text, "Deep Dir Name")
+	require.Contains(t, text, "Ünïcödé Nämé.txt")
+}

--- a/pkg/iso9660/names.go
+++ b/pkg/iso9660/names.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/bgrewell/iso-kit/pkg/iso9660/encoding"
 	"github.com/bgrewell/iso-kit/pkg/iso9660/tree"
 )
 
@@ -89,6 +90,73 @@ func assignIdentifiers(children []*tree.Node, mangled bool) map[*tree.Node]strin
 			id += ";1"
 		}
 		out[child] = id
+	}
+	return out
+}
+
+// Joliet allows 64 UCS-2 characters per identifier.
+const jolietNameMaxLen = 64
+
+// jolietName sanitizes a name for a Joliet directory record: the
+// characters forbidden by the Joliet specification are replaced with '_'
+// and the name is truncated to 64 UTF-16 code units. Case is preserved.
+func jolietName(name string) string {
+	out := make([]rune, 0, len(name))
+	for _, r := range name {
+		switch {
+		case r < 0x20, r == '*', r == '/', r == ':', r == ';', r == '?', r == '\\':
+			out = append(out, '_')
+		default:
+			out = append(out, r)
+		}
+	}
+	// Truncation is by UTF-16 units; supplementary-plane runes cost two.
+	units := 0
+	for i, r := range out {
+		cost := 1
+		if r > 0xFFFF {
+			cost = 2
+		}
+		if units+cost > jolietNameMaxLen {
+			out = out[:i]
+			break
+		}
+		units += cost
+	}
+	if len(out) == 0 {
+		return "_"
+	}
+	return string(out)
+}
+
+// assignJolietIdentifiers produces the UCS-2-encoded on-disk identifier
+// for every child of a directory, deduplicating collisions caused by
+// sanitization or truncation. File identifiers carry the ";1" version
+// suffix before encoding.
+func assignJolietIdentifiers(children []*tree.Node) map[*tree.Node]string {
+	out := make(map[*tree.Node]string, len(children))
+	used := make(map[string]bool, len(children))
+
+	for _, child := range children {
+		name := jolietName(child.Name())
+		if used[name] {
+			for n := 1; ; n++ {
+				tail := fmt.Sprintf("~%d", n)
+				trimmed := name
+				if len(trimmed)+len(tail) > jolietNameMaxLen {
+					trimmed = trimmed[:jolietNameMaxLen-len(tail)]
+				}
+				if candidate := trimmed + tail; !used[candidate] {
+					name = candidate
+					break
+				}
+			}
+		}
+		used[name] = true
+		if !child.IsDir() {
+			name += ";1"
+		}
+		out[child] = string(encoding.EncodeUCS2BigEndian(name))
 	}
 	return out
 }

--- a/pkg/iso9660/pack.go
+++ b/pkg/iso9660/pack.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/bgrewell/iso-kit/pkg/consts"
+	"github.com/bgrewell/iso-kit/pkg/iso9660/descriptor"
 	"github.com/bgrewell/iso-kit/pkg/iso9660/directory"
 	"github.com/bgrewell/iso-kit/pkg/iso9660/extensions"
 	"github.com/bgrewell/iso-kit/pkg/iso9660/pathtable"
@@ -154,13 +155,23 @@ type dirPlan struct {
 	children map[*tree.Node]*recordPlan
 }
 
+// extentRef resolves the extent location and size a directory record
+// should reference for a node. The primary and Joliet hierarchies share
+// file extents but keep separate directory extents.
+type extentRef func(node *tree.Node) (location, size uint32)
+
 // packLayout holds the sector assignments produced by Pack.
 type packLayout struct {
 	pvdSector        uint32
+	svdSector        uint32
 	terminatorSector uint32
 	pathTableLSector uint32
 	pathTableMSector uint32
 	pathTableSize    uint32
+	// Joliet hierarchy sectors (meaningful only when joliet is true).
+	jolietPathTableLSector uint32
+	jolietPathTableMSector uint32
+	jolietPathTableSize    uint32
 	// Continuation area region for Rock Ridge data that does not fit
 	// inline (always at least one sector when Rock Ridge is enabled, for
 	// the ER entry).
@@ -168,6 +179,7 @@ type packLayout struct {
 	contSectors    uint32
 	totalSectors   uint32
 	rockRidge      bool
+	joliet         bool
 	// dirs is the breadth-first directory list; index+1 is each
 	// directory's path table number.
 	dirs []*tree.Node
@@ -176,8 +188,29 @@ type packLayout struct {
 	// identifiers maps every node to its on-disk identifier (path table
 	// and directory records must agree).
 	identifiers map[*tree.Node]string
+	// Joliet record plans, UCS-2 identifiers, and directory extent
+	// locations/sizes (file extents are shared with the primary
+	// hierarchy).
+	jolietPlans       map[*tree.Node]*dirPlan
+	jolietIdentifiers map[*tree.Node]string
+	jolietDirLocation map[*tree.Node]uint32
+	jolietDirSize     map[*tree.Node]uint32
 	// files is every regular file node in tree walk order.
 	files []*tree.Node
+}
+
+// primaryRef resolves extent references for the primary hierarchy.
+func (l *packLayout) primaryRef(node *tree.Node) (uint32, uint32) {
+	return node.PackedLocation, node.PackedSize
+}
+
+// jolietRef resolves extent references for the Joliet hierarchy:
+// directories use the Joliet extent, files share the primary extents.
+func (l *packLayout) jolietRef(node *tree.Node) (uint32, uint32) {
+	if node.IsDir() {
+		return l.jolietDirLocation[node], l.jolietDirSize[node]
+	}
+	return node.PackedLocation, node.PackedSize
 }
 
 // rockRidgeWriteEnabled reports whether the rebuilt image should carry
@@ -410,22 +443,92 @@ func assignContinuationOffsets(dirs []*tree.Node, plans map[*tree.Node]*dirPlan,
 	return block + 1
 }
 
+// buildJolietPlans computes the record plans for the Joliet hierarchy:
+// UCS-2 identifiers, no system use data.
+func buildJolietPlans(dirs []*tree.Node) (map[*tree.Node]*dirPlan, map[*tree.Node]string) {
+	plans := make(map[*tree.Node]*dirPlan, len(dirs))
+	identifiers := make(map[*tree.Node]string)
+
+	for _, dir := range dirs {
+		dp := &dirPlan{
+			dot:      &recordPlan{identifier: "\x00"},
+			dotdot:   &recordPlan{identifier: "\x01"},
+			children: map[*tree.Node]*recordPlan{},
+		}
+		plans[dir] = dp
+
+		children := dir.Children()
+		ids := assignJolietIdentifiers(children)
+		for _, child := range children {
+			identifiers[child] = ids[child]
+			dp.children[child] = &recordPlan{identifier: ids[child]}
+		}
+	}
+	return plans, identifiers
+}
+
+// jolietWriteEnabled reports whether the rebuilt image should carry a
+// Joliet hierarchy: created images follow the create option; opened
+// images preserve Joliet when the source had a Joliet SVD.
+func (iso *ISO9660) jolietWriteEnabled() bool {
+	if iso.createOptions != nil {
+		return iso.createOptions.JolietEnabled
+	}
+	if iso.volumeDescriptorSet != nil {
+		for _, svd := range iso.volumeDescriptorSet.Supplementary {
+			if svd.IsJoliet() {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// jolietSVD returns the SVD to update for the Joliet hierarchy, creating
+// one (mirroring the PVD's identity fields) when the image has none.
+func (iso *ISO9660) jolietSVD() *descriptor.SupplementaryVolumeDescriptor {
+	for _, svd := range iso.volumeDescriptorSet.Supplementary {
+		if svd.IsJoliet() {
+			return svd
+		}
+	}
+	pvd := iso.volumeDescriptorSet.Primary
+	svd := &descriptor.SupplementaryVolumeDescriptor{
+		VolumeDescriptorHeader: descriptor.VolumeDescriptorHeader{
+			VolumeDescriptorType:    descriptor.TYPE_SUPPLEMENTARY_DESCRIPTOR,
+			StandardIdentifier:      consts.ISO9660_STD_IDENTIFIER,
+			VolumeDescriptorVersion: consts.ISO9660_VOLUME_DESC_VERSION,
+		},
+		SupplementaryVolumeDescriptorBody: descriptor.SupplementaryVolumeDescriptorBody{
+			VolumeIdentifier:              pvd.VolumeIdentifier(),
+			DataPreparerIdentifier:        pvd.DataPreparerIdentifier(),
+			VolumeCreationDateAndTime:     pvd.VolumeCreationDateTime(),
+			VolumeModificationDateAndTime: pvd.VolumeModificationDateTime(),
+			FileStructureVersion:          1,
+			Logger:                        iso.logger,
+		},
+	}
+	copy(svd.EscapeSequences[:], consts.JOLIET_LEVEL_3_ESCAPE)
+	iso.volumeDescriptorSet.Supplementary = append(iso.volumeDescriptorSet.Supplementary, svd)
+	return svd
+}
+
 // Pack assigns a sector location to every structure in the image: volume
 // descriptors, path tables, Rock Ridge continuation areas, directory
-// extents, and file extents. It updates the PVD's size and location
-// cross-references so a subsequent Save writes a consistent image. The
-// layout is:
+// extents, and file extents. It updates the PVD's (and, with Joliet, the
+// SVD's) size and location cross-references so a subsequent Save writes a
+// consistent image. The layout is:
 //
 //	sectors 0-15   system area
 //	sector  16     primary volume descriptor
-//	sector  17     volume descriptor set terminator
-//	next           L path table, then M path table
+//	next           supplementary (Joliet) volume descriptor, when enabled
+//	next           volume descriptor set terminator
+//	next           primary L path table, then M path table
+//	next           Joliet L and M path tables, when enabled
 //	next           Rock Ridge continuation area (when enabled)
-//	next           directory extents in breadth-first order (root first)
-//	next           file extents
-//
-// Note: supplementary (Joliet) descriptors are not yet written; a source
-// image's SVDs are dropped from the rebuilt output.
+//	next           primary directory extents in breadth-first order
+//	next           Joliet directory extents, when enabled
+//	next           file extents (shared by both hierarchies)
 func (iso *ISO9660) Pack() error {
 	if iso.root == nil {
 		return fmt.Errorf("no directory tree to pack")
@@ -436,6 +539,7 @@ func (iso *ISO9660) Pack() error {
 	}
 
 	rockRidge := iso.rockRidgeWriteEnabled()
+	joliet := iso.jolietWriteEnabled()
 	dirs := iso.root.Directories()
 	plans, identifiers, err := buildPlans(dirs, rockRidge)
 	if err != nil {
@@ -443,18 +547,31 @@ func (iso *ISO9660) Pack() error {
 	}
 
 	layout := &packLayout{
-		pvdSector:        consts.ISO9660_SYSTEM_AREA_SECTORS,
-		terminatorSector: consts.ISO9660_SYSTEM_AREA_SECTORS + 1,
-		rockRidge:        rockRidge,
-		dirs:             dirs,
-		plans:            plans,
-		identifiers:      identifiers,
+		pvdSector:   consts.ISO9660_SYSTEM_AREA_SECTORS,
+		rockRidge:   rockRidge,
+		joliet:      joliet,
+		dirs:        dirs,
+		plans:       plans,
+		identifiers: identifiers,
 	}
+
+	descriptorSector := layout.pvdSector + 1
+	if joliet {
+		layout.svdSector = descriptorSector
+		descriptorSector++
+		layout.jolietPlans, layout.jolietIdentifiers = buildJolietPlans(dirs)
+		layout.jolietDirLocation = make(map[*tree.Node]uint32, len(dirs))
+		layout.jolietDirSize = make(map[*tree.Node]uint32, len(dirs))
+	}
+	layout.terminatorSector = descriptorSector
 
 	// Directory extent sizes are independent of location, so they can be
 	// computed before sectors are assigned.
 	for _, dir := range dirs {
 		dir.PackedSize = directoryExtentSize(dir, plans[dir])
+		if joliet {
+			layout.jolietDirSize[dir] = directoryExtentSize(dir, layout.jolietPlans[dir])
+		}
 	}
 	layout.pathTableSize = pathTableSize(dirs, identifiers)
 
@@ -463,6 +580,14 @@ func (iso *ISO9660) Pack() error {
 	next += sectorsFor(layout.pathTableSize)
 	layout.pathTableMSector = next
 	next += sectorsFor(layout.pathTableSize)
+
+	if joliet {
+		layout.jolietPathTableSize = pathTableSize(dirs, layout.jolietIdentifiers)
+		layout.jolietPathTableLSector = next
+		next += sectorsFor(layout.jolietPathTableSize)
+		layout.jolietPathTableMSector = next
+		next += sectorsFor(layout.jolietPathTableSize)
+	}
 
 	// The continuation region's size is location-independent; assign its
 	// base here and lay chunks into it.
@@ -473,6 +598,12 @@ func (iso *ISO9660) Pack() error {
 	for _, dir := range dirs {
 		dir.PackedLocation = next
 		next += sectorsFor(dir.PackedSize)
+	}
+	if joliet {
+		for _, dir := range dirs {
+			layout.jolietDirLocation[dir] = next
+			next += sectorsFor(layout.jolietDirSize[dir])
+		}
 	}
 
 	err = iso.root.Walk(func(node *tree.Node) error {
@@ -512,7 +643,30 @@ func (iso *ISO9660) Pack() error {
 
 	// The root directory record embedded in the PVD points at the root
 	// extent. It carries no system use data.
-	pvd.RootDirectoryRecord = buildDirectoryRecord(iso.root, "\x00", nil, iso.root)
+	pvd.RootDirectoryRecord = buildDirectoryRecord(iso.root, "\x00", nil, layout.primaryRef)
+
+	// Update the SVD cross-references for the Joliet hierarchy.
+	if joliet {
+		svd := iso.jolietSVD()
+		svd.VolumeSpaceSize = layout.totalSectors
+		svd.SupplementaryVolumeDescriptorBody.PathTableSize = layout.jolietPathTableSize
+		svd.LocationOfTypeLPathTable = layout.jolietPathTableLSector
+		svd.LocationOfOptionalTypeLPathTable = 0
+		svd.LocationOfTypeMPathTable = layout.jolietPathTableMSector
+		svd.LocationOfOptionalTypeMPathTable = 0
+		svd.ObjectLocation = int64(layout.svdSector) * consts.ISO9660_SECTOR_SIZE
+		svd.SupplementaryVolumeDescriptorBody.ObjectSize = consts.ISO9660_SECTOR_SIZE
+		if svd.LogicalBlockSize == 0 {
+			svd.LogicalBlockSize = consts.ISO9660_SECTOR_SIZE
+		}
+		if svd.VolumeSetSize == 0 {
+			svd.VolumeSetSize = 1
+		}
+		if svd.SupplementaryVolumeDescriptorBody.VolumeSequenceNumber == 0 {
+			svd.SupplementaryVolumeDescriptorBody.VolumeSequenceNumber = 1
+		}
+		svd.RootDirectoryRecord = buildDirectoryRecord(iso.root, "\x00", nil, layout.jolietRef)
+	}
 
 	iso.layout = layout
 	iso.isPacked = true
@@ -529,14 +683,14 @@ func recordingTime(t time.Time) time.Time {
 }
 
 // buildDirectoryRecord constructs the on-disk directory record describing
-// target, using the given identifier and system use field. The record's
-// extent fields come from target's packed location and size, so Pack must
-// run first.
-func buildDirectoryRecord(target *tree.Node, identifier string, systemUse []byte, timeSource *tree.Node) *directory.DirectoryRecord {
+// target with the given extent reference. Pack must run first so the
+// resolver returns assigned locations.
+func buildDirectoryRecord(target *tree.Node, identifier string, systemUse []byte, ref extentRef) *directory.DirectoryRecord {
+	location, size := ref(target)
 	return &directory.DirectoryRecord{
-		LocationOfExtent:       target.PackedLocation,
-		DataLength:             target.PackedSize,
-		RecordingDateAndTime:   recordingTime(timeSource.ModTime()),
+		LocationOfExtent:       location,
+		DataLength:             size,
+		RecordingDateAndTime:   recordingTime(target.ModTime()),
 		FileFlags:              directory.FileFlags{Directory: target.IsDir()},
 		VolumeSequenceNumber:   1,
 		LengthOfFileIdentifier: uint8(len(identifier)),
@@ -547,13 +701,15 @@ func buildDirectoryRecord(target *tree.Node, identifier string, systemUse []byte
 
 // marshalDirectoryExtent serializes a directory's extent: the "." and ".."
 // records followed by one record per child, zero-padding whenever a record
-// would cross a sector boundary. The result is exactly dir.PackedSize bytes.
-func marshalDirectoryExtent(dir *tree.Node, dp *dirPlan) ([]byte, error) {
-	buf := make([]byte, dir.PackedSize)
+// would cross a sector boundary. extentSize is the directory's extent size
+// in the hierarchy being written; ref resolves each record's extent
+// pointer.
+func marshalDirectoryExtent(dir *tree.Node, dp *dirPlan, extentSize uint32, ref extentRef) ([]byte, error) {
+	buf := make([]byte, extentSize)
 	offset := 0
 
 	err := dp.eachPlan(dir, func(target *tree.Node, plan *recordPlan) error {
-		rec := buildDirectoryRecord(target, plan.identifier, plan.systemUse(), target)
+		rec := buildDirectoryRecord(target, plan.identifier, plan.systemUse(), ref)
 		data, err := rec.Marshal()
 		if err != nil {
 			return fmt.Errorf("failed to marshal directory record %q in %q: %w",
@@ -564,7 +720,7 @@ func marshalDirectoryExtent(dir *tree.Node, dp *dirPlan) ([]byte, error) {
 		}
 		if offset+len(data) > len(buf) {
 			return fmt.Errorf("directory extent overflow in %q: computed size %d too small",
-				dir.FullPath(), dir.PackedSize)
+				dir.FullPath(), extentSize)
 		}
 		copy(buf[offset:], data)
 		offset += len(data)
@@ -597,35 +753,53 @@ func (iso *ISO9660) marshalContinuationArea() []byte {
 	return buf
 }
 
-// buildPathTables produces the L (little-endian) and M (big-endian) path
-// tables from the packed directory list. Directory numbering follows the
-// breadth-first order of layout.dirs, so a directory's path table number is
-// its index plus one.
-func (iso *ISO9660) buildPathTables() (*pathtable.PathTable, *pathtable.PathTable, error) {
-	if iso.layout == nil {
-		return nil, nil, fmt.Errorf("image is not packed")
-	}
-
+// buildPathTablePair produces the L (little-endian) and M (big-endian)
+// path tables for one hierarchy. Directory numbering follows the
+// breadth-first order of the packed directory list, so a directory's path
+// table number is its index plus one.
+func (iso *ISO9660) buildPathTablePair(source string, identifiers map[*tree.Node]string, ref extentRef, lSector, mSector, size uint32) (*pathtable.PathTable, *pathtable.PathTable) {
 	dirNumber := make(map[*tree.Node]uint16, len(iso.layout.dirs))
 	for i, dir := range iso.layout.dirs {
 		dirNumber[dir] = uint16(i + 1)
 	}
 
-	ptL := pathtable.NewEmptyPathTable("Primary", true)
-	ptM := pathtable.NewEmptyPathTable("Primary", false)
+	ptL := pathtable.NewEmptyPathTable(source, true)
+	ptM := pathtable.NewEmptyPathTable(source, false)
 	for _, dir := range iso.layout.dirs {
 		identifier := "\x00"
 		parentNumber := uint16(1)
 		if !dir.IsRoot() {
-			identifier = iso.layout.identifiers[dir]
+			identifier = identifiers[dir]
 			parentNumber = dirNumber[dir.Parent()]
 		}
-		ptL.AddRecord(identifier, dir.PackedLocation, parentNumber)
-		ptM.AddRecord(identifier, dir.PackedLocation, parentNumber)
+		location, _ := ref(dir)
+		ptL.AddRecord(identifier, location, parentNumber)
+		ptM.AddRecord(identifier, location, parentNumber)
 	}
 
-	ptL.SetLocation(iso.layout.pathTableLSector, iso.layout.pathTableSize)
-	ptM.SetLocation(iso.layout.pathTableMSector, iso.layout.pathTableSize)
+	ptL.SetLocation(lSector, size)
+	ptM.SetLocation(mSector, size)
 
+	return ptL, ptM
+}
+
+// buildPathTables produces the primary hierarchy's L and M path tables.
+func (iso *ISO9660) buildPathTables() (*pathtable.PathTable, *pathtable.PathTable, error) {
+	if iso.layout == nil {
+		return nil, nil, fmt.Errorf("image is not packed")
+	}
+	ptL, ptM := iso.buildPathTablePair("Primary", iso.layout.identifiers, iso.layout.primaryRef,
+		iso.layout.pathTableLSector, iso.layout.pathTableMSector, iso.layout.pathTableSize)
+	return ptL, ptM, nil
+}
+
+// buildJolietPathTables produces the Joliet hierarchy's L and M path
+// tables with UCS-2 identifiers.
+func (iso *ISO9660) buildJolietPathTables() (*pathtable.PathTable, *pathtable.PathTable, error) {
+	if iso.layout == nil || !iso.layout.joliet {
+		return nil, nil, fmt.Errorf("image is not packed with Joliet")
+	}
+	ptL, ptM := iso.buildPathTablePair("Supplementary", iso.layout.jolietIdentifiers, iso.layout.jolietRef,
+		iso.layout.jolietPathTableLSector, iso.layout.jolietPathTableMSector, iso.layout.jolietPathTableSize)
 	return ptL, ptM, nil
 }


### PR DESCRIPTION
## Summary

Second slice of P2, **stacked on #7** (Rock Ridge): created and modified images can now carry a **Joliet hierarchy** — Windows-readable Unicode names — alongside Rock Ridge. The P1-era behavior of dropping SVDs from rebuilt images is gone.

### SVD typed fields (P1 leftover, prerequisite)
`VolumeSpaceSize` [8]byte → `uint32`; `VolumeSetSize`, `VolumeSequenceNumber`, `LogicalBlockSize` [4]byte → `uint16` — both-byte-order encoding matching the PVD, so `Pack()` can update the SVD programmatically.

### Layout engine: second hierarchy
- SVD written at sector 17 (terminator shifts to 18)
- Joliet L/M path tables follow the primary pair; Joliet directory extents follow the primary extents
- **File data extents are shared** between hierarchies — an extent-reference resolver picks the per-hierarchy directory extent when records and path tables are marshaled
- Joliet identifiers: forbidden characters sanitized, truncated to 64 UTF-16 units with deterministic `~N` dedupe, pre-encoded UCS-2 big-endian in the record plans (this also closes the roadmap's "Joliet directory record marshal" item)

### Behavior
- `Create(name, WithJolietEnabled(true))` writes PVD + SVD
- Opened images with a Joliet SVD keep it automatically across modify→save
- Non-Joliet images are unchanged (no SVD by default)

## Test plan
- Reopen via primary hierarchy (Rock Ridge names) and via `WithPreferJoliet(true)` (UCS-2 names, including `Ünïcödé Nämé.txt`), content resolving through shared extents in both
- 80-char name: truncated to 64 units in Joliet, full name intact via Rock Ridge
- Joliet preserved across Open→AddFile→Save→Open
- xorriso interop: `-read_fs norock` lists the Joliet tree with Unicode names intact
- Full suite green: `go build`, `go vet`, `go test ./...`