### PR TITLE
Add El Torito write support and fix catalog field offsets

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -147,11 +147,26 @@ Goal: proper extension support with spec-compliant serialization.
   - Created images opt in with `WithJolietEnabled(true)`; opened images
     preserve Joliet when the source had it; verified with xorriso
     (`-read_fs norock` shows the Joliet tree with Unicode names)
-- [ ] Fix El Torito entry field offsets to match specification
-  - Byte 0 = Boot Indicator, byte 1 = Boot Media Type, bytes 2-3 = Load Segment
-- [ ] Fix El Torito marshal for multi-boot catalogs with section headers
-- [ ] Implement Boot Information Table support (56-byte table at offset 8)
-- [ ] Integrate El Torito into Create/Save pipeline
+- [x] Fix El Torito entry field offsets to match specification
+  - Byte 0 = Boot Indicator, byte 1 = Boot Media Type, bytes 2-3 = Load
+    Segment, byte 4 = System Type; platform now sourced from the validation
+    entry / section headers instead of misread from the media type byte
+- [x] Fix El Torito marshal for multi-boot catalogs with section headers
+  - Proper validation entry (platform byte, ID string at bytes 4-27,
+    zero-sum checksum); additional entries grouped into 0x90/0x91 sections
+    by platform (BIOS default + EFI section verified with xorriso)
+- [x] Implement Boot Information Table support (56-byte table at offset 8)
+  - Opt-in per entry (`BootInfoTable: true`); PVD LBA, image LBA/length,
+    and word-sum checksum patched at save; recognized by xorriso as
+    `boot-info-table`
+- [x] Integrate El Torito into Create/Save pipeline
+  - `AddBootImage(BootImageConfig)` registers tree files as boot entries;
+    boot record written at sector 17, catalog sector allocated by Pack
+  - Opened bootable images preserve their catalog on modify-save: entries
+    are matched to relocated tree files by source extent, with a raw
+    sector-copy fallback for hidden boot images
+  - Also fixed a uint16 overflow in BuildBootImageEntries sizing for boot
+    images over 128 KB
 - [ ] Wire character validation into descriptor write path
 - [ ] Implement ISO 9660 filename validation (Level 1/2/3)
   - Partially covered by the Rock Ridge identifier mangler; strict

--- a/pkg/iso9660/boot/eltorito.go
+++ b/pkg/iso9660/boot/eltorito.go
@@ -231,42 +231,71 @@ func (et *ElTorito) GetObjects() []info.ImageObject {
 	return []info.ImageObject{et}
 }
 
+// Marshal serializes the boot catalog into one 2048-byte sector following
+// the El Torito specification: a validation entry, the initial/default
+// entry, and — for additional entries — section headers grouping section
+// entries by platform.
 func (et *ElTorito) Marshal() ([]byte, error) {
 	if len(et.Entries) == 0 {
 		return nil, fmt.Errorf("El Torito Boot Catalog has no entries")
 	}
 
-	// Boot Catalog is stored in 2048-byte sectors, ensure correct alignment
 	data := make([]byte, consts.ISO9660_SECTOR_SIZE)
 
-	// 1️⃣ Write Validation Entry (First 32 bytes)
-	data[0] = 0x01                    // Header ID
-	copy(data[1:6], "EL TORITO SPEC") // Identifier
+	// Validation entry (32 bytes): header ID, platform, ID string at
+	// bytes 4-27, checksum at 0x1C making the 16-bit word sum zero, and
+	// the 0x55AA key bytes.
+	data[0] = 0x01
+	data[1] = byte(et.Entries[0].Platform)
+	copy(data[4:28], consts.EL_TORITO_BOOT_SYSTEM_ID)
 	data[0x1E] = 0x55
 	data[0x1F] = 0xAA
-
-	// Compute checksum
-	checksum := uint16(0)
+	var checksum uint16
 	for i := 0; i < 32; i += 2 {
 		checksum += binary.LittleEndian.Uint16(data[i : i+2])
 	}
-	binary.LittleEndian.PutUint16(data[0x1C:0x1E], -checksum) // Store negative checksum
+	binary.LittleEndian.PutUint16(data[0x1C:0x1E], uint16(0x10000-uint32(checksum)))
 
-	// 2️⃣ Write Initial Boot Entry (First Boot Entry, starts at offset 32)
-	offset := 32
-	for _, entry := range et.Entries {
-		if offset+32 > len(data) {
-			return nil, fmt.Errorf("Boot catalog exceeds sector size limit")
+	writeEntry := func(offset int, entry *ElToritoEntry) {
+		if entry.Bootable {
+			data[offset] = 0x88
 		}
+		data[offset+1] = byte(entry.Emulation)
+		binary.LittleEndian.PutUint16(data[offset+2:], entry.LoadSegment)
+		data[offset+4] = byte(entry.PartitionType)
+		binary.LittleEndian.PutUint16(data[offset+6:], entry.size)
+		binary.LittleEndian.PutUint32(data[offset+8:], entry.location)
+	}
 
-		data[offset] = 0x88                    // Boot Indicator (0x88 = Bootable)
-		data[offset+1] = byte(entry.Platform)  // Platform ID
-		data[offset+2] = byte(entry.Emulation) // Emulation Type
-		binary.LittleEndian.PutUint16(data[offset+4:], entry.LoadSegment)
-		binary.LittleEndian.PutUint16(data[offset+6:], entry.size)     // Size in 512-byte blocks
-		binary.LittleEndian.PutUint32(data[offset+8:], entry.location) // Location in 2048-byte sectors
+	// Initial/default entry.
+	offset := 32
+	writeEntry(offset, et.Entries[0])
+	offset += 32
 
-		offset += 32 // Move to next entry
+	// Additional entries are grouped into sections by platform. Each
+	// group gets a section header (0x91 marks the final header).
+	rest := et.Entries[1:]
+	for start := 0; start < len(rest); {
+		end := start + 1
+		for end < len(rest) && rest[end].Platform == rest[start].Platform {
+			end++
+		}
+		if offset+32*(1+end-start) > len(data) {
+			return nil, fmt.Errorf("boot catalog exceeds sector size limit")
+		}
+		headerID := byte(0x90)
+		if end == len(rest) {
+			headerID = 0x91
+		}
+		data[offset] = headerID
+		data[offset+1] = byte(rest[start].Platform)
+		binary.LittleEndian.PutUint16(data[offset+2:], uint16(end-start))
+		offset += 32
+		for _, entry := range rest[start:end] {
+			writeEntry(offset, entry)
+			offset += 32
+		}
+		start = end
 	}
 
 	return data, nil
@@ -286,16 +315,20 @@ func (et *ElTorito) UnmarshalBinary(data []byte) error {
 	}
 
 	// Parse Validation Entry
-	err := parseValidationEntry(data[:32])
+	platform, err := parseValidationEntry(data[:32])
 	if err != nil {
 		if et.Logger != nil {
 			et.Logger.Error(err, "Boot Catalog: invalid Validation Entry")
 		}
 		return fmt.Errorf("Boot Catalog: invalid Validation Entry: %w", err)
 	}
+	et.Platform = platform
 
-	// Parse Boot Entries
+	// Parse Boot Entries. The initial/default entry inherits the
+	// validation entry's platform; section entries inherit their section
+	// header's platform.
 	sectionCount := 0
+	currentPlatform := platform
 	for offset := 32; offset < len(data); offset += 32 {
 		entryData := data[offset : offset+32]
 
@@ -310,6 +343,7 @@ func (et *ElTorito) UnmarshalBinary(data []byte) error {
 		// Handle Section Headers
 		if entryData[0] == 0x90 || entryData[0] == 0x91 {
 			sectionCount = int(binary.LittleEndian.Uint16(entryData[2:4]))
+			currentPlatform = Platform(entryData[1])
 			if et.Logger != nil {
 				et.Logger.Debug("Section header found", "offset", offset, "entries", sectionCount)
 			}
@@ -318,7 +352,7 @@ func (et *ElTorito) UnmarshalBinary(data []byte) error {
 
 		// Parse Section Entries
 		if sectionCount > 0 {
-			entry := parseSectionEntry(entryData)
+			entry := parseCatalogEntry(entryData, currentPlatform)
 			if et.Logger != nil {
 				et.Logger.Trace("Parsed section entry", "entry", entry)
 			}
@@ -328,7 +362,7 @@ func (et *ElTorito) UnmarshalBinary(data []byte) error {
 		}
 
 		// Parse Initial/Default Entry
-		entry := parseInitialEntry(entryData)
+		entry := parseCatalogEntry(entryData, platform)
 		if et.Logger != nil {
 			et.Logger.Trace("Parsed initial entry", "entry", entry)
 		}
@@ -344,13 +378,47 @@ func (et *ElTorito) UnmarshalBinary(data []byte) error {
 type ElToritoEntry struct {
 	Platform      Platform      // Target platform
 	Emulation     Emulation     // Emulation mode
-	BootFile      string        // Path to the boot file
+	BootFile      string        // Path to the boot file (in-image path for write, extraction path after ExtractBootImages)
 	HideBootFile  bool          // Whether to hide the boot file in the filesystem
-	LoadSegment   uint16        // Open segment address
+	Bootable      bool          // Boot indicator (0x88 bootable, 0x00 not)
+	LoadSegment   uint16        // Load segment address (0 => traditional 0x7C0)
 	PartitionType PartitionType // Partition type of the boot file
-	size          uint16        // Size of the boot file in 512-byte blocks
-	location      uint32        // Location of the boot file in 2048-byte sectors
+	// LoadSize overrides the sector count (512-byte units) loaded at
+	// boot. Zero selects the full image size. BIOS boot loaders such as
+	// isolinux conventionally use 4.
+	LoadSize uint16
+	// BootInfoTable requests a 56-byte boot information table be patched
+	// into the image at offset 8 when the image is written (isolinux
+	// -boot-info-table semantics).
+	BootInfoTable bool
+	size          uint16 // Size of the boot file in 512-byte blocks
+	location      uint32 // Location of the boot file in 2048-byte sectors
 }
+
+// SetExtent records where the boot image lives in the output image:
+// location in 2048-byte sectors and size in bytes. The catalog's sector
+// count field is derived as 512-byte units, honoring LoadSize when set.
+func (e *ElToritoEntry) SetExtent(location uint32, sizeBytes uint32) {
+	e.location = location
+	if e.LoadSize != 0 {
+		e.size = e.LoadSize
+		return
+	}
+	blocks := (sizeBytes + 511) / 512
+	if blocks > 0xFFFF {
+		blocks = 0xFFFF
+	}
+	if blocks == 0 {
+		blocks = 1
+	}
+	e.size = uint16(blocks)
+}
+
+// Location returns the boot image's location in 2048-byte sectors.
+func (e *ElToritoEntry) Location() uint32 { return e.location }
+
+// SectorCount returns the catalog's load sector count in 512-byte units.
+func (e *ElToritoEntry) SectorCount() uint16 { return e.size }
 
 // SectionHeader represents a header for grouping entries in the boot catalog.
 type SectionHeader struct {
@@ -399,7 +467,7 @@ func (et *ElTorito) BuildBootImageEntries() ([]*filesystem.FileSystemEntry, erro
 			Name:       filename,
 			FullPath:   "/[BOOT]/" + filename, // Logical path inside the ISO
 			IsDir:      false,
-			Size:       uint32(entry.size * 512), // Convert 512-byte block size
+			Size:       uint32(entry.size) * 512, // Convert 512-byte block size
 			Location:   entry.location,
 			Mode:       0444,        // Read-only boot image
 			CreateTime: time.Time{}, // No real timestamp in El Torito
@@ -498,44 +566,39 @@ func IsElTorito(bootSystemIdentifier string) bool {
 	return trimmed == consts.EL_TORITO_BOOT_SYSTEM_ID
 }
 
-func parseInitialEntry(data []byte) *ElToritoEntry {
+// parseCatalogEntry decodes an initial or section entry per the El Torito
+// specification: byte 0 boot indicator, byte 1 boot media type, bytes 2-3
+// load segment, byte 4 system (partition) type, bytes 6-7 sector count,
+// bytes 8-11 load RBA. The platform comes from the validation entry or
+// enclosing section header, not the entry itself.
+func parseCatalogEntry(data []byte, platform Platform) *ElToritoEntry {
 	return &ElToritoEntry{
-		Platform:      Platform(data[1]),
-		Emulation:     Emulation(data[2]),
-		LoadSegment:   binary.LittleEndian.Uint16(data[4:6]),
+		Platform:      platform,
+		Bootable:      data[0] == 0x88,
+		Emulation:     Emulation(data[1] & 0x0F),
+		LoadSegment:   binary.LittleEndian.Uint16(data[2:4]),
 		PartitionType: PartitionType(data[4]),
 		size:          binary.LittleEndian.Uint16(data[6:8]),
 		location:      binary.LittleEndian.Uint32(data[8:12]),
 	}
 }
 
-func parseSectionEntry(data []byte) *ElToritoEntry {
-	return &ElToritoEntry{
-		Platform:      Platform(data[1]),
-		Emulation:     Emulation(data[2]),
-		LoadSegment:   binary.LittleEndian.Uint16(data[4:6]),
-		PartitionType: PartitionType(data[4]),
-		size:          binary.LittleEndian.Uint16(data[6:8]),
-		location:      binary.LittleEndian.Uint32(data[8:12]),
-	}
-}
-
-func parseValidationEntry(data []byte) error {
+func parseValidationEntry(data []byte) (Platform, error) {
 	if len(data) < 32 {
-		return fmt.Errorf("Validation Entry: data too short")
+		return 0, fmt.Errorf("Validation Entry: data too short")
 	}
 	if data[0] != 0x01 {
-		return fmt.Errorf("Validation Entry: invalid header ID %x", data[0])
+		return 0, fmt.Errorf("Validation Entry: invalid header ID %x", data[0])
 	}
 	checksum := uint16(0)
 	for i := 0; i < 32; i += 2 {
 		checksum += binary.LittleEndian.Uint16(data[i : i+2])
 	}
 	if checksum != 0 {
-		return fmt.Errorf("Validation Entry: checksum invalid")
+		return 0, fmt.Errorf("Validation Entry: checksum invalid")
 	}
 	if data[0x1E] != 0x55 || data[0x1F] != 0xAA {
-		return fmt.Errorf("Validation Entry: invalid key bytes %x%x", data[0x1E], data[0x1F])
+		return 0, fmt.Errorf("Validation Entry: invalid key bytes %x%x", data[0x1E], data[0x1F])
 	}
-	return nil
+	return Platform(data[1]), nil
 }

--- a/pkg/iso9660/eltorito_test.go
+++ b/pkg/iso9660/eltorito_test.go
@@ -1,0 +1,186 @@
+package iso9660
+
+import (
+	"encoding/binary"
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/bgrewell/iso-kit/pkg/iso9660/boot"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeBootImage returns content resembling a boot loader image: non-zero
+// bytes with recognizable structure, larger than one virtual sector.
+func fakeBootImage(size int) []byte {
+	data := make([]byte, size)
+	for i := range data {
+		data[i] = byte(i * 7)
+	}
+	return data
+}
+
+func createBootableImage(t *testing.T) string {
+	t.Helper()
+	iso, err := Create("BOOTVOL")
+	require.NoError(t, err)
+	require.NoError(t, iso.AddFile("isolinux/isolinux.bin", fakeBootImage(24*1024)))
+	require.NoError(t, iso.AddFile("EFI/BOOT/efiboot.img", fakeBootImage(1440*1024)))
+	require.NoError(t, iso.AddBootImage(BootImageConfig{
+		Path:      "isolinux/isolinux.bin",
+		Platform:  boot.BIOS,
+		Emulation: boot.NoEmulation,
+		LoadSize:  4,
+	}))
+	require.NoError(t, iso.AddBootImage(BootImageConfig{
+		Path:      "EFI/BOOT/efiboot.img",
+		Platform:  boot.EFI,
+		Emulation: boot.NoEmulation,
+	}))
+	return saveToTempFile(t, iso)
+}
+
+func TestElToritoCreateAndReopen(t *testing.T) {
+	path := createBootableImage(t)
+
+	f, err := os.Open(path)
+	require.NoError(t, err)
+	defer f.Close()
+
+	reopened, err := Open(f)
+	require.NoError(t, err)
+	require.True(t, reopened.HasElTorito(), "reopened image should report El Torito")
+
+	bootEntries, err := reopened.ListBootEntries()
+	require.NoError(t, err)
+	require.Len(t, bootEntries, 2)
+
+	// The BIOS entry loads 4 virtual sectors; the EFI entry the full image.
+	require.Equal(t, uint32(4*512), bootEntries[0].Size)
+	require.Equal(t, uint32(((1440*1024)+511)/512*512), bootEntries[1].Size)
+
+	// The boot file content is still readable through the filesystem and
+	// matches what went in (the catalog references the same extent).
+	data, err := reopened.ReadFile("isolinux/isolinux.bin")
+	require.NoError(t, err)
+	require.Equal(t, fakeBootImage(24*1024), data)
+}
+
+func TestElToritoCatalogRoundTrip(t *testing.T) {
+	path := createBootableImage(t)
+
+	f, err := os.Open(path)
+	require.NoError(t, err)
+	defer f.Close()
+
+	reopened, err := Open(f)
+	require.NoError(t, err)
+	require.NotNil(t, reopened.elTorito)
+	require.Len(t, reopened.elTorito.Entries, 2)
+
+	first, second := reopened.elTorito.Entries[0], reopened.elTorito.Entries[1]
+	require.Equal(t, boot.BIOS, first.Platform)
+	require.Equal(t, boot.NoEmulation, first.Emulation)
+	require.True(t, first.Bootable)
+	require.Equal(t, uint16(4), first.SectorCount())
+
+	require.Equal(t, boot.EFI, second.Platform)
+	require.True(t, second.Bootable)
+}
+
+func TestElToritoPreservedOnModify(t *testing.T) {
+	basePath := createBootableImage(t)
+
+	base, err := os.Open(basePath)
+	require.NoError(t, err)
+	defer base.Close()
+
+	opened, err := Open(base)
+	require.NoError(t, err)
+	require.NoError(t, opened.AddFile("extra.txt", []byte("added after boot setup")))
+	modPath := saveToTempFile(t, opened)
+
+	mod, err := os.Open(modPath)
+	require.NoError(t, err)
+	defer mod.Close()
+
+	final, err := Open(mod)
+	require.NoError(t, err)
+	require.True(t, final.HasElTorito(), "boot catalog should survive modification")
+
+	entries, err := final.ListBootEntries()
+	require.NoError(t, err)
+	require.Len(t, entries, 2)
+
+	// The boot image extent was relocated with its file; verify the
+	// catalog points at content identical to the original image.
+	require.NotNil(t, final.elTorito)
+	loc := final.elTorito.Entries[0].Location()
+	require.NotZero(t, loc)
+	imgData := make([]byte, 4*512)
+	_, err = mod.ReadAt(imgData, int64(loc)*2048)
+	require.NoError(t, err)
+	require.Equal(t, fakeBootImage(24 * 1024)[:4*512], imgData)
+}
+
+func TestElToritoBootInfoTable(t *testing.T) {
+	iso, err := Create("BINFOTBL")
+	require.NoError(t, err)
+	img := fakeBootImage(24 * 1024)
+	require.NoError(t, iso.AddFile("isolinux.bin", img))
+	require.NoError(t, iso.AddBootImage(BootImageConfig{
+		Path:          "isolinux.bin",
+		Platform:      boot.BIOS,
+		Emulation:     boot.NoEmulation,
+		LoadSize:      4,
+		BootInfoTable: true,
+	}))
+	path := saveToTempFile(t, iso)
+
+	f, err := os.Open(path)
+	require.NoError(t, err)
+	defer f.Close()
+
+	reopened, err := Open(f)
+	require.NoError(t, err)
+	require.NotNil(t, reopened.elTorito)
+	loc := reopened.elTorito.Entries[0].Location()
+
+	written := make([]byte, len(img))
+	_, err = f.ReadAt(written, int64(loc)*2048)
+	require.NoError(t, err)
+
+	// Table at offset 8: PVD LBA, image LBA, image length, checksum.
+	require.Equal(t, uint32(16), binary.LittleEndian.Uint32(written[8:12]))
+	require.Equal(t, loc, binary.LittleEndian.Uint32(written[12:16]))
+	require.Equal(t, uint32(len(img)), binary.LittleEndian.Uint32(written[16:20]))
+
+	var wantSum uint32
+	for i := 64; i < len(written); i += 4 {
+		wantSum += binary.LittleEndian.Uint32(written[i : i+4])
+	}
+	require.Equal(t, wantSum, binary.LittleEndian.Uint32(written[20:24]))
+
+	// Bytes outside the table are untouched.
+	require.Equal(t, img[:8], written[:8])
+	require.Equal(t, img[64:], written[64:])
+}
+
+// TestElToritoInteropXorriso verifies that xorriso recognizes the boot
+// catalog, platforms, and load sizes of a created image.
+func TestElToritoInteropXorriso(t *testing.T) {
+	xorriso, err := exec.LookPath("xorriso")
+	if err != nil {
+		t.Skip("xorriso not available")
+	}
+
+	path := createBootableImage(t)
+
+	out, err := exec.Command(xorriso, "-indev", path, "-report_el_torito", "plain").CombinedOutput()
+	require.NoError(t, err, "xorriso failed: %s", out)
+	text := string(out)
+
+	require.Contains(t, text, "El Torito catalog")
+	require.Contains(t, text, "BIOS")
+	require.Contains(t, text, "UEFI")
+}

--- a/pkg/iso9660/iso9660.go
+++ b/pkg/iso9660/iso9660.go
@@ -2,6 +2,7 @@ package iso9660
 
 import (
 	"cmp"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"github.com/bgrewell/iso-kit/pkg/consts"
@@ -769,6 +770,60 @@ func (iso *ISO9660) markDirty() {
 	iso.filesystemEntries = nil
 }
 
+// BootImageConfig describes a boot image to register in the El Torito
+// boot catalog. The image itself must already exist as a file in the ISO
+// (via AddFile or AddLocalDirectory).
+type BootImageConfig struct {
+	// Path of the boot image file inside the ISO.
+	Path string
+	// Platform the entry boots (BIOS, EFI, ...).
+	Platform boot.Platform
+	// Emulation mode; NoEmulation for modern loaders.
+	Emulation boot.Emulation
+	// LoadSegment for BIOS boots; 0 selects the traditional 0x7C0.
+	LoadSegment uint16
+	// LoadSize overrides the sector count (512-byte units) loaded by the
+	// firmware. Zero derives it from the image size. BIOS loaders such as
+	// isolinux conventionally use 4.
+	LoadSize uint16
+	// BootInfoTable patches a 56-byte boot information table into the
+	// image at offset 8 during Save (isolinux -boot-info-table).
+	BootInfoTable bool
+}
+
+// AddBootImage registers a boot image in the El Torito boot catalog. The
+// first image added becomes the initial/default entry; additional images
+// become section entries (e.g. a BIOS default plus an EFI section).
+func (iso *ISO9660) AddBootImage(cfg BootImageConfig) error {
+	if iso.root == nil {
+		return errors.New("no filesystem is loaded")
+	}
+	node := iso.root.Lookup(cfg.Path)
+	if node == nil {
+		return fmt.Errorf("boot image not found in the image: %s", cfg.Path)
+	}
+	if node.IsDir() {
+		return fmt.Errorf("boot image path is a directory: %s", cfg.Path)
+	}
+	if iso.elTorito == nil {
+		iso.elTorito = &boot.ElTorito{
+			Platform: cfg.Platform,
+			Logger:   iso.logger,
+		}
+	}
+	iso.elTorito.Entries = append(iso.elTorito.Entries, &boot.ElToritoEntry{
+		Platform:      cfg.Platform,
+		Emulation:     cfg.Emulation,
+		BootFile:      node.FullPath(),
+		Bootable:      true,
+		LoadSegment:   cfg.LoadSegment,
+		LoadSize:      cfg.LoadSize,
+		BootInfoTable: cfg.BootInfoTable,
+	})
+	iso.markDirty()
+	return nil
+}
+
 // CreateDirectories creates all directories from the ISO in the specified path.
 func (iso *ISO9660) CreateDirectories(path string) error {
 	// Ensure output directory exists
@@ -991,10 +1046,6 @@ func (iso *ISO9660) saveRebuild(writer io.WriterAt) error {
 		return errors.New("no filesystem is loaded")
 	}
 
-	if iso.volumeDescriptorSet.Boot != nil || iso.elTorito != nil {
-		iso.logger.Info("WARNING: El Torito boot structures are not yet supported in rebuilt images; the output will not be bootable")
-	}
-
 	if err := iso.Pack(); err != nil {
 		return fmt.Errorf("failed to pack image: %w", err)
 	}
@@ -1011,6 +1062,24 @@ func (iso *ISO9660) saveRebuild(writer io.WriterAt) error {
 	}
 	if _, err := writer.WriteAt(pvdBytes, int64(iso.layout.pvdSector)*consts.ISO9660_SECTOR_SIZE); err != nil {
 		return fmt.Errorf("failed to write primary volume descriptor: %w", err)
+	}
+
+	// 2a. El Torito boot record and catalog.
+	if iso.layout.elTorito {
+		brBytes, err := iso.volumeDescriptorSet.Boot.Marshal()
+		if err != nil {
+			return fmt.Errorf("failed to marshal boot record: %w", err)
+		}
+		if _, err := writer.WriteAt(brBytes, int64(iso.layout.bootRecordSector)*consts.ISO9660_SECTOR_SIZE); err != nil {
+			return fmt.Errorf("failed to write boot record: %w", err)
+		}
+		catalogBytes, err := iso.elTorito.Marshal()
+		if err != nil {
+			return fmt.Errorf("failed to marshal boot catalog: %w", err)
+		}
+		if _, err := writer.WriteAt(catalogBytes, int64(iso.layout.bootCatalogSector)*consts.ISO9660_SECTOR_SIZE); err != nil {
+			return fmt.Errorf("failed to write boot catalog: %w", err)
+		}
 	}
 
 	// 2b. Supplementary (Joliet) volume descriptor.
@@ -1117,7 +1186,66 @@ func (iso *ISO9660) saveRebuild(writer io.WriterAt) error {
 		}
 	}
 
+	// 8. Boot image blobs preserved from the source image, and boot
+	// information table patches.
+	if iso.layout.elTorito {
+		for _, blob := range iso.layout.bootBlobs {
+			if iso.isoReader == nil {
+				return errors.New("cannot preserve boot image: no source image reader")
+			}
+			padded := int64(sectorsFor(blob.sizeBytes)) * consts.ISO9660_SECTOR_SIZE
+			data := make([]byte, padded)
+			if _, err := iso.isoReader.ReadAt(data[:blob.sizeBytes], int64(blob.srcSector)*consts.ISO9660_SECTOR_SIZE); err != nil {
+				return fmt.Errorf("failed to read boot image extent at sector %d: %w", blob.srcSector, err)
+			}
+			if _, err := writer.WriteAt(data, int64(blob.dstSector)*consts.ISO9660_SECTOR_SIZE); err != nil {
+				return fmt.Errorf("failed to write boot image extent: %w", err)
+			}
+		}
+		for entry, node := range iso.layout.bootImageNodes {
+			if !entry.BootInfoTable {
+				continue
+			}
+			if err := iso.patchBootInfoTable(writer, node); err != nil {
+				return err
+			}
+		}
+	}
+
 	iso.isDirty = false
+	return nil
+}
+
+// patchBootInfoTable writes the 56-byte boot information table into a
+// boot image at offset 8 (isolinux -boot-info-table): PVD LBA, the
+// image's LBA and byte length, and a checksum over the 32-bit words from
+// offset 64 to the end of the image.
+func (iso *ISO9660) patchBootInfoTable(writer io.WriterAt, node *tree.Node) error {
+	content, err := node.ReadData(consts.ISO9660_SECTOR_SIZE)
+	if err != nil {
+		return fmt.Errorf("failed to read boot image for info table: %w", err)
+	}
+	if len(content) < 64 {
+		return fmt.Errorf("boot image %q too small for a boot info table (%d bytes)", node.FullPath(), len(content))
+	}
+
+	var checksum uint32
+	for i := 64; i < len(content); i += 4 {
+		var word [4]byte
+		copy(word[:], content[i:min(i+4, len(content))])
+		checksum += binary.LittleEndian.Uint32(word[:])
+	}
+
+	table := make([]byte, 56)
+	binary.LittleEndian.PutUint32(table[0:], consts.ISO9660_SYSTEM_AREA_SECTORS) // PVD LBA
+	binary.LittleEndian.PutUint32(table[4:], node.PackedLocation)
+	binary.LittleEndian.PutUint32(table[8:], uint32(len(content)))
+	binary.LittleEndian.PutUint32(table[12:], checksum)
+
+	offset := int64(node.PackedLocation)*consts.ISO9660_SECTOR_SIZE + 8
+	if _, err := writer.WriteAt(table, offset); err != nil {
+		return fmt.Errorf("failed to patch boot info table into %q: %w", node.FullPath(), err)
+	}
 	return nil
 }
 

--- a/pkg/iso9660/pack.go
+++ b/pkg/iso9660/pack.go
@@ -1,11 +1,13 @@
 package iso9660
 
 import (
+	"encoding/binary"
 	"fmt"
 	"io/fs"
 	"time"
 
 	"github.com/bgrewell/iso-kit/pkg/consts"
+	"github.com/bgrewell/iso-kit/pkg/iso9660/boot"
 	"github.com/bgrewell/iso-kit/pkg/iso9660/descriptor"
 	"github.com/bgrewell/iso-kit/pkg/iso9660/directory"
 	"github.com/bgrewell/iso-kit/pkg/iso9660/extensions"
@@ -160,10 +162,21 @@ type dirPlan struct {
 // file extents but keep separate directory extents.
 type extentRef func(node *tree.Node) (location, size uint32)
 
+// bootBlob is a boot image extent preserved from a source image that has
+// no corresponding file in the directory tree; its raw sectors are copied
+// into the rebuilt image.
+type bootBlob struct {
+	entry     *boot.ElToritoEntry
+	srcSector uint32
+	sizeBytes uint32
+	dstSector uint32
+}
+
 // packLayout holds the sector assignments produced by Pack.
 type packLayout struct {
 	pvdSector        uint32
 	svdSector        uint32
+	bootRecordSector uint32
 	terminatorSector uint32
 	pathTableLSector uint32
 	pathTableMSector uint32
@@ -177,9 +190,16 @@ type packLayout struct {
 	// the ER entry).
 	contBaseSector uint32
 	contSectors    uint32
-	totalSectors   uint32
-	rockRidge      bool
-	joliet         bool
+	// Boot catalog sector (meaningful only when elTorito is true).
+	bootCatalogSector uint32
+	totalSectors      uint32
+	rockRidge         bool
+	joliet            bool
+	elTorito          bool
+	// bootImageNodes maps catalog entries to the tree files backing them.
+	bootImageNodes map[*boot.ElToritoEntry]*tree.Node
+	// bootBlobs preserves boot image extents with no tree counterpart.
+	bootBlobs []*bootBlob
 	// dirs is the breadth-first directory list; index+1 is each
 	// directory's path table number.
 	dirs []*tree.Node
@@ -540,6 +560,7 @@ func (iso *ISO9660) Pack() error {
 
 	rockRidge := iso.rockRidgeWriteEnabled()
 	joliet := iso.jolietWriteEnabled()
+	elTorito := iso.elTorito != nil && len(iso.elTorito.Entries) > 0
 	dirs := iso.root.Directories()
 	plans, identifiers, err := buildPlans(dirs, rockRidge)
 	if err != nil {
@@ -550,12 +571,19 @@ func (iso *ISO9660) Pack() error {
 		pvdSector:   consts.ISO9660_SYSTEM_AREA_SECTORS,
 		rockRidge:   rockRidge,
 		joliet:      joliet,
+		elTorito:    elTorito,
 		dirs:        dirs,
 		plans:       plans,
 		identifiers: identifiers,
 	}
 
 	descriptorSector := layout.pvdSector + 1
+	if elTorito {
+		// The El Torito specification requires the boot record at
+		// sector 17, immediately after the PVD.
+		layout.bootRecordSector = descriptorSector
+		descriptorSector++
+	}
 	if joliet {
 		layout.svdSector = descriptorSector
 		descriptorSector++
@@ -595,6 +623,11 @@ func (iso *ISO9660) Pack() error {
 	layout.contSectors = assignContinuationOffsets(dirs, plans, layout.contBaseSector)
 	next += layout.contSectors
 
+	if elTorito {
+		layout.bootCatalogSector = next
+		next++
+	}
+
 	for _, dir := range dirs {
 		dir.PackedLocation = next
 		next += sectorsFor(dir.PackedSize)
@@ -618,6 +651,52 @@ func (iso *ISO9660) Pack() error {
 	})
 	if err != nil {
 		return err
+	}
+
+	// Resolve boot catalog entries to their image extents: entries added
+	// via AddBootImage reference tree files by path; entries parsed from
+	// a source image are matched to tree files by their original extent
+	// location, falling back to a raw sector copy of the old extent.
+	if elTorito {
+		layout.bootImageNodes = make(map[*boot.ElToritoEntry]*tree.Node)
+		srcIndex := make(map[uint32]*tree.Node)
+		_ = iso.root.Walk(func(node *tree.Node) error {
+			if loc, ok := node.SourceLocation(); ok {
+				srcIndex[loc] = node
+			}
+			return nil
+		})
+		for _, entry := range iso.elTorito.Entries {
+			switch {
+			case entry.BootFile != "":
+				node := iso.root.Lookup(entry.BootFile)
+				if node == nil || node.IsDir() {
+					return fmt.Errorf("boot image %q not found in the image", entry.BootFile)
+				}
+				layout.bootImageNodes[entry] = node
+				entry.SetExtent(node.PackedLocation, node.Size())
+			case srcIndex[entry.Location()] != nil:
+				node := srcIndex[entry.Location()]
+				// Preserve the parsed sector count; the file may be
+				// larger than what the firmware loads at boot.
+				if entry.LoadSize == 0 {
+					entry.LoadSize = entry.SectorCount()
+				}
+				layout.bootImageNodes[entry] = node
+				entry.SetExtent(node.PackedLocation, node.Size())
+			default:
+				// No tree counterpart (e.g. hidden boot image): copy the
+				// raw extent. Only the loaded portion is known.
+				sizeBytes := uint32(entry.SectorCount()) * 512
+				blob := &bootBlob{entry: entry, srcSector: entry.Location(), sizeBytes: sizeBytes, dstSector: next}
+				next += sectorsFor(sizeBytes)
+				layout.bootBlobs = append(layout.bootBlobs, blob)
+				if entry.LoadSize == 0 {
+					entry.LoadSize = entry.SectorCount()
+				}
+				entry.SetExtent(blob.dstSector, sizeBytes)
+			}
+		}
 	}
 
 	layout.totalSectors = next
@@ -644,6 +723,30 @@ func (iso *ISO9660) Pack() error {
 	// The root directory record embedded in the PVD points at the root
 	// extent. It carries no system use data.
 	pvd.RootDirectoryRecord = buildDirectoryRecord(iso.root, "\x00", nil, layout.primaryRef)
+
+	// Update (or build) the boot record descriptor pointing at the boot
+	// catalog.
+	if elTorito {
+		br := iso.volumeDescriptorSet.Boot
+		if br == nil {
+			br = &descriptor.BootRecordDescriptor{
+				VolumeDescriptorHeader: descriptor.VolumeDescriptorHeader{
+					VolumeDescriptorType:    descriptor.TYPE_BOOT_RECORD,
+					StandardIdentifier:      consts.ISO9660_STD_IDENTIFIER,
+					VolumeDescriptorVersion: consts.ISO9660_VOLUME_DESC_VERSION,
+				},
+			}
+			iso.volumeDescriptorSet.Boot = br
+		}
+		br.BootSystemIdentifier = consts.EL_TORITO_BOOT_SYSTEM_ID
+		br.BootRecordBody.BootSystemUse = [descriptor.BOOT_SYSTEM_USE_SIZE]byte{}
+		binary.LittleEndian.PutUint32(br.BootRecordBody.BootSystemUse[0:4], layout.bootCatalogSector)
+		br.BootRecordBody.ObjectLocation = int64(layout.bootRecordSector) * consts.ISO9660_SECTOR_SIZE
+		br.BootRecordBody.ObjectSize = consts.ISO9660_SECTOR_SIZE
+
+		iso.elTorito.ObjectLocation = int64(layout.bootCatalogSector) * consts.ISO9660_SECTOR_SIZE
+		iso.elTorito.ObjectSize = consts.ISO9660_SECTOR_SIZE
+	}
 
 	// Update the SVD cross-references for the Joliet hierarchy.
 	if joliet {

--- a/pkg/iso9660/tree/tree.go
+++ b/pkg/iso9660/tree/tree.go
@@ -100,6 +100,16 @@ func (n *Node) SetOwnership(uid, gid uint32) { n.uid, n.gid = uid, gid }
 // IsSymlink reports whether the node is a symbolic link.
 func (n *Node) IsSymlink() bool { return n.symlinkTarget != "" }
 
+// SourceLocation returns the node's extent sector in the backing image it
+// was parsed from, and whether the node is backed by such an image.
+// In-memory (pending) nodes report false.
+func (n *Node) SourceLocation() (uint32, bool) {
+	if n.reader == nil || n.data != nil {
+		return 0, false
+	}
+	return n.location, true
+}
+
 // SymlinkTarget returns the symlink target path, or "" for non-links.
 func (n *Node) SymlinkTarget() string { return n.symlinkTarget }
 


### PR DESCRIPTION
## Summary

Final major slice of P2, **stacked on #8** (Joliet): created and modified images can now be **bootable**, and the El Torito catalog encoding is spec-correct for the first time.

### Fixed: catalog field offsets (parse and marshal)
The analysis flagged this as an interop landmine: parse and marshal shared the same wrong layout, so internal round-trips worked while any exchange with other tools would corrupt catalogs. Per spec now:
- Byte 0 boot indicator, byte 1 boot media type, bytes 2-3 load segment, byte 4 system type, bytes 6-7 sector count, bytes 8-11 load RBA
- Platform comes from the validation entry / section headers (it was previously misread from the media type byte)
- Validation entry: platform byte at 1, ID string at bytes 4-27 (was written over the platform byte), checksum makes the 16-bit word sum zero
- Multi-boot: additional entries grouped into 0x90/0x91 section headers by platform

### New: write pipeline integration
- `AddBootImage(BootImageConfig{Path, Platform, Emulation, LoadSegment, LoadSize, BootInfoTable})` registers a file already in the tree as a boot entry; first entry is the initial/default, later ones become sections (BIOS default + EFI section)
- Pack places the boot record at **sector 17** as the spec requires, allocates the catalog sector, and resolves entries to packed extents
- Opened bootable images **preserve their catalog on modify-save**: entries matched to relocated tree files by source extent location, raw sector-copy fallback for hidden boot images
- Opt-in **boot information table** (isolinux `-boot-info-table`): 56-byte table with PVD LBA, image LBA/length, and word-sum checksum patched at offset 8 during Save

### Also
- Fixed uint16 overflow in `BuildBootImageEntries` truncating reported sizes of boot images >128 KB (surfaced by the new tests)

## Test plan
- Create→Save→Open: catalog reports both entries, platforms, sector counts; boot file content readable and identical
- Open→AddFile→Save→Open: catalog survives, relocated extent content verified byte-for-byte
- Boot info table: PVD LBA/image LBA/length/checksum verified, surrounding bytes untouched
- xorriso `-report_el_torito`: both entries listed with correct platforms (BIOS/UEFI), load sizes (4 / 2880), resolved paths, and the boot-info-table auto-detected
- Full suite green: `go build`, `go vet`, `go test ./...`