### PR TITLE
Add hybrid boot support: MBR partition tables and GPT

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -190,9 +190,17 @@ Goal: UDF support, USB-bootable hybrid ISOs, production CLI, comprehensive testi
 - [ ] UDF Volume Recognition Sequence and AVDP parsing
 - [ ] UDF volume descriptor and partition parsing (ECMA-167)
 - [ ] UDF file system traversal (FSD → ICB → File Entry → FID)
-- [ ] System area MBR partition table parsing and generation
-- [ ] GPT support for UEFI hybrid ISOs
-- [ ] Isohybrid post-processing (MBR + GPT after ISO build)
+- [x] System area MBR partition table parsing and generation
+  - `systemarea.MBR` with parse (`ParseMBR`), marshal, CHS synthesis
+- [x] GPT support for UEFI hybrid ISOs
+  - `systemarea.GPT`: primary + backup headers with CRC32s, 128-entry
+    array, deterministic GUIDs for reproducible output
+- [x] Isohybrid post-processing (MBR + GPT after ISO build)
+  - `SetHybridBoot(HybridBootConfig)`: MBR-only mode writes the classic
+    isohybrid layout (bootable whole-image partition + 0xEF ESP entry);
+    GPT mode writes a protective MBR + GPT with the EFI System Partition
+    and a backup GPT appended after the ISO data
+  - Verified with fdisk and parted: GPT disklabel and ESP recognized
 - [ ] Rebuild `isocreate` CLI with proper argument parsing
 - [ ] Comprehensive unit tests (directory, parser, pathtable, extensions, eltorito)
 - [ ] CI pipeline (GitHub Actions) + README update

--- a/pkg/iso9660/hybrid_test.go
+++ b/pkg/iso9660/hybrid_test.go
@@ -1,0 +1,145 @@
+package iso9660
+
+import (
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/bgrewell/iso-kit/pkg/iso9660/boot"
+	"github.com/bgrewell/iso-kit/pkg/iso9660/systemarea"
+	"github.com/stretchr/testify/require"
+)
+
+func createHybridImage(t *testing.T, addGPT bool) string {
+	t.Helper()
+	iso, err := Create("HYBRID")
+	require.NoError(t, err)
+
+	require.NoError(t, iso.AddFile("isolinux/isolinux.bin", fakeBootImage(24*1024)))
+	require.NoError(t, iso.AddFile("EFI/BOOT/efiboot.img", fakeBootImage(1440*1024)))
+	require.NoError(t, iso.AddBootImage(BootImageConfig{
+		Path:      "isolinux/isolinux.bin",
+		Platform:  boot.BIOS,
+		Emulation: boot.NoEmulation,
+		LoadSize:  4,
+	}))
+	require.NoError(t, iso.AddBootImage(BootImageConfig{
+		Path:      "EFI/BOOT/efiboot.img",
+		Platform:  boot.EFI,
+		Emulation: boot.NoEmulation,
+	}))
+
+	bootCode := make([]byte, 432)
+	copy(bootCode, "FAKE-ISOHDPFX-BOOTCODE")
+	require.NoError(t, iso.SetHybridBoot(HybridBootConfig{
+		MBRBootCode:      bootCode,
+		EFIBootImagePath: "EFI/BOOT/efiboot.img",
+		AddGPT:           addGPT,
+	}))
+	return saveToTempFile(t, iso)
+}
+
+func TestHybridBootMBR(t *testing.T) {
+	path := createHybridImage(t, false)
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	mbr := systemarea.ParseMBR(data)
+	require.NotNil(t, mbr, "image should carry an MBR boot signature")
+
+	// Boot code survived.
+	require.Equal(t, []byte("FAKE-ISOHDPFX-BOOTCODE"), mbr.BootCode[:22])
+
+	// Partition 1: bootable, covers the whole image.
+	p1 := mbr.Partitions[0]
+	require.Equal(t, byte(0x80), p1.Status)
+	require.Equal(t, byte(systemarea.MBR_TYPE_ISO9660), p1.Type)
+	require.Equal(t, uint32(0), p1.StartLBA)
+	require.Equal(t, uint32(len(data)/512), p1.SizeLBA)
+
+	// Partition 2: EFI system partition over the ESP image extent.
+	p2 := mbr.Partitions[1]
+	require.Equal(t, byte(systemarea.MBR_TYPE_EFI_SYSTEM), p2.Type)
+	require.NotZero(t, p2.StartLBA)
+	require.Equal(t, uint32((1440*1024)/512), p2.SizeLBA)
+
+	// The partition points at the actual ESP content.
+	espStart := int64(p2.StartLBA) * 512
+	require.Equal(t, fakeBootImage(1440 * 1024)[:64], data[espStart:espStart+64])
+
+	// The ISO filesystem is still intact.
+	f, err := os.Open(path)
+	require.NoError(t, err)
+	defer f.Close()
+	reopened, err := Open(f)
+	require.NoError(t, err)
+	require.True(t, reopened.HasElTorito())
+}
+
+func TestHybridBootGPT(t *testing.T) {
+	path := createHybridImage(t, true)
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.Zero(t, len(data)%512, "image should be LBA aligned")
+
+	// Primary GPT header at LBA 1.
+	require.Equal(t, []byte("EFI PART"), data[512:520])
+
+	// Backup GPT header occupies the final LBA.
+	backup := data[len(data)-512:]
+	require.Equal(t, []byte("EFI PART"), backup[:8])
+
+	// The image still opens as an ISO 9660 filesystem.
+	f, err := os.Open(path)
+	require.NoError(t, err)
+	defer f.Close()
+	reopened, err := Open(f)
+	require.NoError(t, err)
+	data2, err := reopened.ReadFile("isolinux/isolinux.bin")
+	require.NoError(t, err)
+	require.Equal(t, fakeBootImage(24*1024), data2)
+}
+
+func TestHybridBootValidation(t *testing.T) {
+	iso, err := Create("HVAL")
+	require.NoError(t, err)
+	require.NoError(t, iso.AddFile("esp.img", []byte("x")))
+
+	// Boot code too large.
+	err = iso.SetHybridBoot(HybridBootConfig{MBRBootCode: make([]byte, 441)})
+	require.Error(t, err)
+
+	// GPT without an ESP image.
+	err = iso.SetHybridBoot(HybridBootConfig{AddGPT: true})
+	require.Error(t, err)
+
+	// ESP path that does not exist.
+	err = iso.SetHybridBoot(HybridBootConfig{EFIBootImagePath: "missing.img"})
+	require.Error(t, err)
+}
+
+// TestHybridInteropFdisk verifies that standard partition tools read the
+// hybrid partition tables.
+func TestHybridInteropFdisk(t *testing.T) {
+	fdisk, err := exec.LookPath("fdisk")
+	if err != nil {
+		t.Skip("fdisk not available")
+	}
+
+	// MBR-only image.
+	path := createHybridImage(t, false)
+	out, err := exec.Command(fdisk, "-l", path).CombinedOutput()
+	require.NoError(t, err, "fdisk failed: %s", out)
+	text := string(out)
+	require.Contains(t, text, "EFI (FAT-12/16/32)", "fdisk should identify the 0xEF partition")
+
+	// GPT image: fdisk should recognize the GPT and the ESP entry.
+	gptPath := createHybridImage(t, true)
+	out, err = exec.Command(fdisk, "-l", gptPath).CombinedOutput()
+	require.NoError(t, err, "fdisk failed: %s", out)
+	text = string(out)
+	require.Contains(t, text, "gpt", "fdisk should detect the GPT disklabel")
+	require.Contains(t, text, "EFI System", "fdisk should list the EFI System Partition")
+}

--- a/pkg/iso9660/iso9660.go
+++ b/pkg/iso9660/iso9660.go
@@ -293,6 +293,8 @@ type ISO9660 struct {
 	root *tree.Node
 	// Sector assignments produced by Pack
 	layout *packLayout
+	// Hybrid (USB) boot configuration applied during Save
+	hybridBoot *HybridBootConfig
 	// Logger
 	logger *logging.Logger
 	// isPacked represents if the ISO9660 filesystem is packed and ready to write to disk
@@ -775,6 +777,49 @@ func (iso *ISO9660) markDirty() {
 	iso.filesystemEntries = nil
 }
 
+// HybridBootConfig describes the system-area partition structures that
+// make an ISO image bootable when written directly to a USB drive or
+// disk ("isohybrid"). The El Torito catalog handles optical boot; these
+// structures cover BIOS and UEFI firmware reading the medium as a hard
+// disk.
+type HybridBootConfig struct {
+	// MBRBootCode is x86 boot code for the first 440 bytes of the image
+	// (e.g. syslinux's isohdpfx.bin). Optional; without it the MBR only
+	// carries the partition table, which suffices for UEFI-only boot.
+	MBRBootCode []byte
+	// EFIBootImagePath is the in-ISO path of the EFI system partition
+	// image (typically the same file registered with AddBootImage for
+	// the EFI platform). When set, the MBR gains a type 0xEF partition
+	// over the image, and with AddGPT an EFI System Partition entry.
+	EFIBootImagePath string
+	// AddGPT writes a GUID partition table (primary and backup) with an
+	// EFI System Partition entry. Requires EFIBootImagePath.
+	AddGPT bool
+	// PartitionType is the MBR type code of the whole-image partition.
+	// Zero selects 0xCD, the value GRUB hybrid images use.
+	PartitionType byte
+}
+
+// SetHybridBoot configures isohybrid partition structures to be written
+// into the system area during Save, making the image USB-bootable.
+func (iso *ISO9660) SetHybridBoot(cfg HybridBootConfig) error {
+	if len(cfg.MBRBootCode) > 440 {
+		return fmt.Errorf("MBR boot code is %d bytes; the boot code area holds at most 440", len(cfg.MBRBootCode))
+	}
+	if cfg.AddGPT && cfg.EFIBootImagePath == "" {
+		return errors.New("AddGPT requires EFIBootImagePath")
+	}
+	if cfg.EFIBootImagePath != "" {
+		node := iso.root.Lookup(cfg.EFIBootImagePath)
+		if node == nil || node.IsDir() {
+			return fmt.Errorf("EFI boot image not found in the image: %s", cfg.EFIBootImagePath)
+		}
+	}
+	iso.hybridBoot = &cfg
+	iso.markDirty()
+	return nil
+}
+
 // BootImageConfig describes a boot image to register in the El Torito
 // boot catalog. The image itself must already exist as a file in the ISO
 // (via AddFile or AddLocalDirectory).
@@ -1229,7 +1274,131 @@ func (iso *ISO9660) saveRebuild(writer io.WriterAt) error {
 		}
 	}
 
+	// 9. Hybrid boot structures (MBR partition table and optional GPT)
+	// patched into the system area and image tail.
+	if iso.hybridBoot != nil {
+		if err := iso.applyHybridBoot(writer); err != nil {
+			return err
+		}
+	}
+
 	iso.isDirty = false
+	return nil
+}
+
+// applyHybridBoot writes the isohybrid MBR (and optionally GPT) into the
+// image: the MBR occupies the first 512 bytes of the system area, the
+// primary GPT LBAs 1-33, and the backup GPT a padded region appended
+// after the ISO 9660 data.
+func (iso *ISO9660) applyHybridBoot(writer io.WriterAt) error {
+	cfg := iso.hybridBoot
+
+	// Device size in 512-byte LBAs: the ISO data plus, with GPT, a
+	// 2048-aligned tail region holding the backup structures (33 LBAs
+	// rounded up to 40 = ten 2048-byte sectors).
+	totalLBAs := uint64(iso.layout.totalSectors) * 4
+	if cfg.AddGPT {
+		totalLBAs += 40
+	}
+
+	var efiStartLBA, efiSizeLBA uint32
+	if cfg.EFIBootImagePath != "" {
+		node := iso.root.Lookup(cfg.EFIBootImagePath)
+		if node == nil || node.IsDir() {
+			return fmt.Errorf("EFI boot image not found in the image: %s", cfg.EFIBootImagePath)
+		}
+		efiStartLBA = node.PackedLocation * 4
+		efiSizeLBA = (uint32(node.Size()) + 511) / 512
+		if efiSizeLBA == 0 {
+			return fmt.Errorf("EFI boot image %s is empty", cfg.EFIBootImagePath)
+		}
+	}
+
+	// Build the MBR. With GPT, a protective MBR (single 0xEE partition
+	// from LBA 1) is required — partition tools ignore a GPT that is not
+	// announced this way, and the ESP lives in the GPT instead. Without
+	// GPT, the classic isohybrid layout: a bootable whole-image
+	// partition plus a type 0xEF entry over the ESP image.
+	mbr := &systemarea.MBR{}
+	copy(mbr.BootCode[:], cfg.MBRBootCode)
+	if cfg.AddGPT {
+		mbr.Partitions[0] = systemarea.MBRPartition{
+			Status:   0x80, // bootable for BIOS firmware that requires an active partition
+			Type:     systemarea.MBR_TYPE_GPT_PROTECTIVE,
+			StartLBA: 1,
+			SizeLBA:  uint32(totalLBAs - 1),
+		}
+	} else {
+		partType := cfg.PartitionType
+		if partType == 0 {
+			partType = systemarea.MBR_TYPE_ISO9660
+		}
+		mbr.Partitions[0] = systemarea.MBRPartition{
+			Status:   0x80,
+			Type:     partType,
+			StartLBA: 0,
+			SizeLBA:  uint32(totalLBAs),
+		}
+		if efiSizeLBA > 0 {
+			mbr.Partitions[1] = systemarea.MBRPartition{
+				Status:   0x00,
+				Type:     systemarea.MBR_TYPE_EFI_SYSTEM,
+				StartLBA: efiStartLBA,
+				SizeLBA:  efiSizeLBA,
+			}
+		}
+	}
+	mbrBytes := mbr.Marshal()
+	if _, err := writer.WriteAt(mbrBytes, 0); err != nil {
+		return fmt.Errorf("failed to write hybrid MBR: %w", err)
+	}
+	// Keep the in-memory system area consistent for later saves.
+	copy(iso.systemArea.Contents[:512], mbrBytes)
+
+	if !cfg.AddGPT {
+		return nil
+	}
+
+	gpt := &systemarea.GPT{
+		Partitions: []systemarea.GPTPartition{{
+			TypeGUID: systemarea.GUID_EFI_SYSTEM,
+			FirstLBA: uint64(efiStartLBA),
+			LastLBA:  uint64(efiStartLBA) + uint64(efiSizeLBA) - 1,
+			Name:     "EFI System Partition",
+		}},
+	}
+	gptLayout, err := gpt.Build(totalLBAs)
+	if err != nil {
+		return fmt.Errorf("failed to build GPT: %w", err)
+	}
+
+	writes := []struct {
+		data []byte
+		lba  uint64
+	}{
+		{gptLayout.PrimaryHeader, 1},
+		{gptLayout.Entries, 2},
+		{gptLayout.BackupEntries, totalLBAs - 1 - 32},
+		{gptLayout.BackupHeader, totalLBAs - 1},
+	}
+	for _, w := range writes {
+		if _, err := writer.WriteAt(w.data, int64(w.lba)*512); err != nil {
+			return fmt.Errorf("failed to write GPT structure at LBA %d: %w", w.lba, err)
+		}
+	}
+	copy(iso.systemArea.Contents[512:512+len(gptLayout.PrimaryHeader)], gptLayout.PrimaryHeader)
+	copy(iso.systemArea.Contents[1024:1024+len(gptLayout.Entries)], gptLayout.Entries)
+
+	// Zero-fill the tail region between the ISO data and the backup GPT
+	// so the appended area is fully initialized.
+	isoEnd := int64(iso.layout.totalSectors) * consts.ISO9660_SECTOR_SIZE
+	backupStart := int64(totalLBAs-1-32) * 512
+	if gap := backupStart - isoEnd; gap > 0 {
+		if _, err := writer.WriteAt(make([]byte, gap), isoEnd); err != nil {
+			return fmt.Errorf("failed to pad GPT tail region: %w", err)
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/iso9660/systemarea/gpt.go
+++ b/pkg/iso9660/systemarea/gpt.go
@@ -1,0 +1,153 @@
+package systemarea
+
+import (
+	"encoding/binary"
+	"fmt"
+	"hash/crc32"
+
+	"github.com/bgrewell/iso-kit/pkg/iso9660/encoding"
+)
+
+const (
+	gptSignature      = "EFI PART"
+	gptRevision       = 0x00010000
+	gptHeaderSize     = 92
+	gptEntrySize      = 128
+	gptEntryCount     = 128
+	gptEntriesLBAs    = gptEntryCount * gptEntrySize / 512 // 32 sectors
+	gptPrimaryLBA     = 1
+	gptEntriesLBA     = 2
+	gptFirstUsableLBA = gptEntriesLBA + gptEntriesLBAs // 34
+)
+
+// Partition type GUIDs (mixed-endian on disk).
+var (
+	// GUID_EFI_SYSTEM is C12A7328-F81F-11D2-BA4B-00A0C93EC93B.
+	GUID_EFI_SYSTEM = [16]byte{0x28, 0x73, 0x2A, 0xC1, 0x1F, 0xF8, 0xD2, 0x11, 0xBA, 0x4B, 0x00, 0xA0, 0xC9, 0x3E, 0xC9, 0x3B}
+	// GUID_BASIC_DATA is EBD0A0A2-B9E5-4433-87C0-68B6B72699C7.
+	GUID_BASIC_DATA = [16]byte{0xA2, 0xA0, 0xD0, 0xEB, 0xE5, 0xB9, 0x33, 0x44, 0x87, 0xC0, 0x68, 0xB6, 0xB7, 0x26, 0x99, 0xC7}
+)
+
+// GPTPartition is one GUID partition table entry. LBA values are in
+// 512-byte units.
+type GPTPartition struct {
+	TypeGUID   [16]byte
+	UniqueGUID [16]byte
+	FirstLBA   uint64
+	LastLBA    uint64 // inclusive
+	Name       string // up to 36 UTF-16 units
+}
+
+// GPT models a GUID partition table for a hybrid ISO image: primary
+// header at LBA 1, entry array at LBA 2-33, and a backup at the end of
+// the device.
+type GPT struct {
+	DiskGUID   [16]byte
+	Partitions []GPTPartition
+}
+
+// deterministicGUID derives a stable GUID from a seed, keeping image
+// output reproducible. The variant/version bits are set to look like a
+// random (v4) GUID.
+func deterministicGUID(seed string) [16]byte {
+	var g [16]byte
+	sum := crc32.ChecksumIEEE([]byte(seed))
+	for i := range g {
+		g[i] = byte(sum >> (uint(i%4) * 8))
+		sum = sum*1664525 + 1013904223
+	}
+	g[7] = g[7]&0x0F | 0x40
+	g[8] = g[8]&0x3F | 0x80
+	return g
+}
+
+func (g *GPT) marshalEntries() []byte {
+	entries := make([]byte, gptEntryCount*gptEntrySize)
+	for i, p := range g.Partitions {
+		e := entries[i*gptEntrySize:]
+		copy(e[0:16], p.TypeGUID[:])
+		copy(e[16:32], p.UniqueGUID[:])
+		binary.LittleEndian.PutUint64(e[32:40], p.FirstLBA)
+		binary.LittleEndian.PutUint64(e[40:48], p.LastLBA)
+		// Attributes (8 bytes) left zero.
+		name := encoding.EncodeUCS2BigEndian(p.Name)
+		// GPT names are UTF-16LE; swap byte order and cap at 72 bytes.
+		if len(name) > 72 {
+			name = name[:72]
+		}
+		for j := 0; j+1 < len(name); j += 2 {
+			e[56+j] = name[j+1]
+			e[56+j+1] = name[j]
+		}
+	}
+	return entries
+}
+
+func (g *GPT) marshalHeader(currentLBA, backupLBA, entriesLBA, totalLBAs uint64, entriesCRC uint32) []byte {
+	h := make([]byte, 512)
+	copy(h[0:8], gptSignature)
+	binary.LittleEndian.PutUint32(h[8:12], gptRevision)
+	binary.LittleEndian.PutUint32(h[12:16], gptHeaderSize)
+	// CRC (16:20) computed last.
+	binary.LittleEndian.PutUint64(h[24:32], currentLBA)
+	binary.LittleEndian.PutUint64(h[32:40], backupLBA)
+	binary.LittleEndian.PutUint64(h[40:48], gptFirstUsableLBA)
+	binary.LittleEndian.PutUint64(h[48:56], totalLBAs-gptEntriesLBAs-2) // last usable
+	copy(h[56:72], g.DiskGUID[:])
+	binary.LittleEndian.PutUint64(h[72:80], entriesLBA)
+	binary.LittleEndian.PutUint32(h[80:84], gptEntryCount)
+	binary.LittleEndian.PutUint32(h[84:88], gptEntrySize)
+	binary.LittleEndian.PutUint32(h[88:92], entriesCRC)
+	crc := crc32.ChecksumIEEE(h[:gptHeaderSize])
+	binary.LittleEndian.PutUint32(h[16:20], crc)
+	return h
+}
+
+// GPTLayout is the serialized form of a GPT for a device of totalLBAs
+// 512-byte sectors: the pieces are written at fixed device offsets.
+type GPTLayout struct {
+	// Primary header, written at LBA 1.
+	PrimaryHeader []byte
+	// Entry array, written at LBA 2.
+	Entries []byte
+	// Backup entry array, written at totalLBAs-33.
+	BackupEntries []byte
+	// Backup header, written at totalLBAs-1.
+	BackupHeader []byte
+	// TotalLBAs is the device size the layout was computed for.
+	TotalLBAs uint64
+}
+
+// Build produces the on-disk GPT structures for a device of totalLBAs
+// 512-byte sectors. The backup structures occupy the final 33 LBAs.
+func (g *GPT) Build(totalLBAs uint64) (*GPTLayout, error) {
+	if len(g.Partitions) > gptEntryCount {
+		return nil, fmt.Errorf("too many GPT partitions: %d", len(g.Partitions))
+	}
+	if totalLBAs < gptFirstUsableLBA+gptEntriesLBAs+2 {
+		return nil, fmt.Errorf("device too small for GPT: %d LBAs", totalLBAs)
+	}
+	var zero [16]byte
+	if g.DiskGUID == zero {
+		g.DiskGUID = deterministicGUID("iso-kit-disk")
+	}
+	for i := range g.Partitions {
+		if g.Partitions[i].UniqueGUID == zero {
+			g.Partitions[i].UniqueGUID = deterministicGUID(fmt.Sprintf("iso-kit-part-%d-%s", i, g.Partitions[i].Name))
+		}
+	}
+
+	entries := g.marshalEntries()
+	entriesCRC := crc32.ChecksumIEEE(entries)
+
+	backupHeaderLBA := totalLBAs - 1
+	backupEntriesLBA := totalLBAs - 1 - gptEntriesLBAs
+
+	return &GPTLayout{
+		PrimaryHeader: g.marshalHeader(gptPrimaryLBA, backupHeaderLBA, gptEntriesLBA, totalLBAs, entriesCRC),
+		Entries:       entries,
+		BackupEntries: entries,
+		BackupHeader:  g.marshalHeader(backupHeaderLBA, gptPrimaryLBA, backupEntriesLBA, totalLBAs, entriesCRC),
+		TotalLBAs:     totalLBAs,
+	}, nil
+}

--- a/pkg/iso9660/systemarea/mbr.go
+++ b/pkg/iso9660/systemarea/mbr.go
@@ -1,0 +1,136 @@
+package systemarea
+
+import (
+	"encoding/binary"
+	"fmt"
+)
+
+const (
+	// MBR layout offsets within the first 512 bytes of the image.
+	mbrBootCodeSize       = 440
+	mbrDiskSignatureStart = 440
+	mbrPartitionTableOff  = 446
+	mbrPartitionEntrySize = 16
+	mbrPartitionCount     = 4
+	mbrSignatureOff       = 510
+
+	// Partition types commonly used in hybrid ISO images.
+	MBR_TYPE_EMPTY          = 0x00
+	MBR_TYPE_HIDDEN_NTFS    = 0x17 // classic isohybrid whole-image partition
+	MBR_TYPE_LINUX          = 0x83
+	MBR_TYPE_ISO9660        = 0xCD // used by GRUB hybrid images
+	MBR_TYPE_EFI_SYSTEM     = 0xEF
+	MBR_TYPE_GPT_PROTECTIVE = 0xEE
+)
+
+// MBRPartition is one entry of the MBR partition table. LBA values are in
+// 512-byte units.
+type MBRPartition struct {
+	// Status is 0x80 for the active (bootable) partition, 0x00 otherwise.
+	Status byte
+	// Type is the partition type code (e.g. 0xEF for an EFI system
+	// partition).
+	Type byte
+	// StartLBA is the first 512-byte sector of the partition.
+	StartLBA uint32
+	// SizeLBA is the partition length in 512-byte sectors.
+	SizeLBA uint32
+}
+
+// IsEmpty reports whether the entry is unused.
+func (p MBRPartition) IsEmpty() bool {
+	return p.Type == MBR_TYPE_EMPTY && p.SizeLBA == 0
+}
+
+// MBR models the master boot record occupying the first 512 bytes of the
+// system area of a hybrid ISO image.
+type MBR struct {
+	// BootCode is the x86 boot code area (up to 440 bytes, e.g.
+	// syslinux's isohdpfx.bin truncated to fit).
+	BootCode [mbrBootCodeSize]byte
+	// DiskSignature is the 32-bit disk identifier at offset 440.
+	DiskSignature uint32
+	// Partitions is the four-entry partition table.
+	Partitions [mbrPartitionCount]MBRPartition
+}
+
+// HasBootSignature reports whether data carries the 0x55AA MBR signature.
+func HasBootSignature(data []byte) bool {
+	return len(data) >= 512 && data[mbrSignatureOff] == 0x55 && data[mbrSignatureOff+1] == 0xAA
+}
+
+// ParseMBR decodes an MBR from the first 512 bytes of a system area.
+// Returns nil if the boot signature is absent.
+func ParseMBR(data []byte) *MBR {
+	if !HasBootSignature(data) {
+		return nil
+	}
+	mbr := &MBR{
+		DiskSignature: binary.LittleEndian.Uint32(data[mbrDiskSignatureStart : mbrDiskSignatureStart+4]),
+	}
+	copy(mbr.BootCode[:], data[:mbrBootCodeSize])
+	for i := 0; i < mbrPartitionCount; i++ {
+		entry := data[mbrPartitionTableOff+i*mbrPartitionEntrySize:]
+		mbr.Partitions[i] = MBRPartition{
+			Status:   entry[0],
+			Type:     entry[4],
+			StartLBA: binary.LittleEndian.Uint32(entry[8:12]),
+			SizeLBA:  binary.LittleEndian.Uint32(entry[12:16]),
+		}
+	}
+	return mbr
+}
+
+// chsBeyond is the conventional CHS value for partitions addressed purely
+// by LBA on media larger than CHS can express.
+var chsBeyond = [3]byte{0xFE, 0xFF, 0xFF}
+
+// chsFor computes a CHS tuple for an LBA using the 64-head, 32-sector
+// geometry isohybrid assumes, saturating at the CHS limit.
+func chsFor(lba uint32) [3]byte {
+	const heads, sectors = 64, 32
+	cylinder := lba / (heads * sectors)
+	if cylinder > 1023 {
+		return chsBeyond
+	}
+	head := (lba / sectors) % heads
+	sector := lba%sectors + 1
+	return [3]byte{
+		byte(head),
+		byte(sector&0x3F) | byte((cylinder>>2)&0xC0),
+		byte(cylinder & 0xFF),
+	}
+}
+
+// Marshal encodes the MBR into its 512-byte on-disk form.
+func (m *MBR) Marshal() []byte {
+	out := make([]byte, 512)
+	copy(out[:mbrBootCodeSize], m.BootCode[:])
+	binary.LittleEndian.PutUint32(out[mbrDiskSignatureStart:], m.DiskSignature)
+	for i, p := range m.Partitions {
+		if p.IsEmpty() {
+			continue
+		}
+		entry := out[mbrPartitionTableOff+i*mbrPartitionEntrySize:]
+		entry[0] = p.Status
+		startCHS := chsFor(p.StartLBA)
+		copy(entry[1:4], startCHS[:])
+		entry[4] = p.Type
+		endCHS := chsFor(p.StartLBA + p.SizeLBA - 1)
+		copy(entry[5:8], endCHS[:])
+		binary.LittleEndian.PutUint32(entry[8:12], p.StartLBA)
+		binary.LittleEndian.PutUint32(entry[12:16], p.SizeLBA)
+	}
+	out[mbrSignatureOff] = 0x55
+	out[mbrSignatureOff+1] = 0xAA
+	return out
+}
+
+// SetPartition sets partition table entry index (0-3).
+func (m *MBR) SetPartition(index int, p MBRPartition) error {
+	if index < 0 || index >= mbrPartitionCount {
+		return fmt.Errorf("partition index %d out of range", index)
+	}
+	m.Partitions[index] = p
+	return nil
+}


### PR DESCRIPTION
## Summary

First P3 slice: images can now be made **USB-bootable** (isohybrid). **Stacked on #11** — merge #10, #11, then this.

### `systemarea` additions
- **MBR**: parse/marshal with CHS synthesis (64-head/32-sector isohybrid geometry), partition type constants
- **GPT**: primary + backup headers with CRC32s, 128-entry array with UTF-16LE names, deterministic GUIDs for reproducible builds

### `SetHybridBoot(HybridBootConfig)`
Applied at the end of Save, after layout is final:
- **MBR-only mode** (classic isohybrid): optional 440-byte boot code (isohdpfx.bin), bootable whole-image partition (default type 0xCD), type 0xEF entry over the ESP image extent
- **GPT mode**: protective MBR (0xEE from LBA 1, marked bootable for picky BIOS firmware) + GPT with the EFI System Partition entry; backup GPT in a 2048-aligned region appended after the ISO data

Design note: partition tools (libfdisk, parted) ignore a GPT that is not announced by a protective 0xEE MBR entry — discovered during verification, hence the two-mode layout matching what Fedora (GPT) and Debian (MBR-only) hybrid images ship.

## Test plan
- MBR image: boot code preserved, partition 1 bootable covering the whole image, partition 2 = ESP at the correct extent with content verified
- GPT image: primary header at LBA 1, backup at the final LBA, ISO filesystem still opens and reads
- Config validation: oversized boot code, GPT without ESP, missing ESP path
- Interop: **fdisk** identifies the 0xEF partition (MBR mode) and reports `Disklabel type: gpt` + `EFI System` (GPT mode); **parted** shows the ESP with `boot, esp` flags
- Full suite green