### PR TITLE
Add UDF read support

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -186,10 +186,18 @@ Goal: proper extension support with spec-compliant serialization.
 
 Goal: UDF support, USB-bootable hybrid ISOs, production CLI, comprehensive testing.
 
-- [ ] Fix UDF detection (scan Volume Recognition Sequence at sectors 16+)
-- [ ] UDF Volume Recognition Sequence and AVDP parsing
-- [ ] UDF volume descriptor and partition parsing (ECMA-167)
-- [ ] UDF file system traversal (FSD → ICB → File Entry → FID)
+- [x] Fix UDF detection (scan Volume Recognition Sequence at sectors 16+)
+  - `udf.IsUDF` scans the VRS for NSR02/NSR03; iso.Open dispatches on it
+    (previously probed sector 256 for "BEA01", which lives at sector 16)
+- [x] UDF Volume Recognition Sequence and AVDP parsing
+- [x] UDF volume descriptor and partition parsing (ECMA-167)
+  - Descriptor tags with checksum verification, PVD, PD, LVD; main VDS
+    with reserve fallback; OSTA compressed unicode dstrings; timestamps
+- [x] UDF file system traversal (FSD → ICB → File Entry → FID)
+  - FE and EFE ICBs; short_ad, long_ad, and inline allocation; multi-
+    extent content via the segmented reader; symlink path components;
+    POSIX permissions/uid/gid mapping; read-only (mutations return
+    ErrWriteUnsupported instead of panicking)
 - [x] System area MBR partition table parsing and generation
   - `systemarea.MBR` with parse (`ParseMBR`), marshal, CHS synthesis
 - [x] GPT support for UEFI hybrid ISOs

--- a/iso.go
+++ b/iso.go
@@ -82,24 +82,20 @@ func Open(filename string, opts ...option.OpenOption) (ISO, error) {
 		return nil, err
 	}
 
-	// Detect ISO9660
+	// Detect ISO9660. Bridge discs carry both an ISO 9660 descriptor and
+	// a UDF recognition sequence; the richer ISO 9660 implementation is
+	// preferred for those.
 	if string(header[1:6]) == consts.ISO9660_STD_IDENTIFIER {
 		return iso9660.Open(f, opts...)
 	}
 
-	// Check if file is large enough to be a valid UDF ISO
-	if fileInfo.Size() < 256*consts.UDF_SECTOR_SIZE {
-		f.Close()
-		return nil, errors.New("file is too small to be a valid ISO9660 or UDF ISO")
+	// Detect UDF by scanning the Volume Recognition Sequence (sectors
+	// 16+) for an NSR descriptor.
+	if udf.IsUDF(f) {
+		return udf.Open(f, opts...)
 	}
 
-	// Read UDF anchor volume descriptor at sector 256 (offset 524288)
-	if _, err = f.ReadAt(header[:], 256*consts.UDF_SECTOR_SIZE); err == nil {
-		if string(header[1:5]) == consts.UDF_STD_IDENTIFIER {
-			return udf.Open(f, opts...)
-		}
-	}
-
+	f.Close()
 	return nil, errors.New("unsupported ISO format")
 }
 

--- a/pkg/udf/descriptor.go
+++ b/pkg/udf/descriptor.go
@@ -1,0 +1,408 @@
+package udf
+
+import (
+	"encoding/binary"
+	"fmt"
+	"time"
+)
+
+// ECMA-167 / UDF structure layouts, read-path scope.
+
+const (
+	// UDF sector (logical block) size used by essentially all UDF media.
+	SectorSize = 2048
+
+	// The Volume Recognition Sequence starts at byte offset 32768
+	// (sector 16) per ECMA-167 part 2.
+	vrsStartSector = 16
+
+	// The Anchor Volume Descriptor Pointer is at sector 256 (with
+	// backups at N-256 and N-1).
+	anchorSector = 256
+
+	// Descriptor tag identifiers (ECMA-167 part 3 & 4).
+	TAG_PRIMARY_VOLUME_DESCRIPTOR     = 1
+	TAG_ANCHOR_VOLUME_DESCRIPTOR_PTR  = 2
+	TAG_VOLUME_DESCRIPTOR_PTR         = 3
+	TAG_IMPLEMENTATION_USE_DESCRIPTOR = 4
+	TAG_PARTITION_DESCRIPTOR          = 5
+	TAG_LOGICAL_VOLUME_DESCRIPTOR     = 6
+	TAG_UNALLOCATED_SPACE_DESCRIPTOR  = 7
+	TAG_TERMINATING_DESCRIPTOR        = 8
+	TAG_FILE_SET_DESCRIPTOR           = 256
+	TAG_FILE_IDENTIFIER_DESCRIPTOR    = 257
+	TAG_FILE_ENTRY                    = 261
+	TAG_EXTENDED_FILE_ENTRY           = 266
+
+	// ICB file types.
+	FILE_TYPE_DIRECTORY = 4
+	FILE_TYPE_REGULAR   = 5
+	FILE_TYPE_SYMLINK   = 12
+
+	// File identifier characteristics bits.
+	FID_CHAR_HIDDEN    = 0x01
+	FID_CHAR_DIRECTORY = 0x02
+	FID_CHAR_DELETED   = 0x04
+	FID_CHAR_PARENT    = 0x08
+)
+
+// Tag is the 16-byte descriptor tag prefixing every ECMA-167 descriptor.
+type Tag struct {
+	ID       uint16
+	Version  uint16
+	Location uint32
+}
+
+// parseTag decodes and verifies a descriptor tag. The checksum byte must
+// match the sum of the other 15 tag bytes.
+func parseTag(data []byte) (Tag, error) {
+	if len(data) < 16 {
+		return Tag{}, fmt.Errorf("descriptor tag: data too short")
+	}
+	var sum byte
+	for i := 0; i < 16; i++ {
+		if i == 4 {
+			continue
+		}
+		sum += data[i]
+	}
+	if sum != data[4] {
+		return Tag{}, fmt.Errorf("descriptor tag: checksum mismatch")
+	}
+	return Tag{
+		ID:       binary.LittleEndian.Uint16(data[0:2]),
+		Version:  binary.LittleEndian.Uint16(data[2:4]),
+		Location: binary.LittleEndian.Uint32(data[12:16]),
+	}, nil
+}
+
+// ExtentAD is an extent_ad: a length in bytes and an absolute sector.
+type ExtentAD struct {
+	Length   uint32
+	Location uint32
+}
+
+func parseExtentAD(data []byte) ExtentAD {
+	return ExtentAD{
+		Length:   binary.LittleEndian.Uint32(data[0:4]),
+		Location: binary.LittleEndian.Uint32(data[4:8]),
+	}
+}
+
+// LongAD is a long_ad: an extent length plus a logical block address
+// within a numbered partition.
+type LongAD struct {
+	Length       uint32
+	LogicalBlock uint32
+	Partition    uint16
+}
+
+func parseLongAD(data []byte) LongAD {
+	return LongAD{
+		Length:       binary.LittleEndian.Uint32(data[0:4]) & 0x3FFFFFFF,
+		LogicalBlock: binary.LittleEndian.Uint32(data[4:8]),
+		Partition:    binary.LittleEndian.Uint16(data[8:10]),
+	}
+}
+
+// decodeDString decodes an OSTA compressed unicode dstring of the given
+// used length: the first byte is the compression ID (8 for latin-1, 16
+// for UCS-2 big-endian).
+func decodeDString(data []byte) string {
+	if len(data) == 0 {
+		return ""
+	}
+	comp := data[0]
+	content := data[1:]
+	switch comp {
+	case 8:
+		runes := make([]rune, len(content))
+		for i, b := range content {
+			runes[i] = rune(b)
+		}
+		return string(runes)
+	case 16:
+		runes := make([]rune, 0, len(content)/2)
+		for i := 0; i+1 < len(content); i += 2 {
+			runes = append(runes, rune(uint16(content[i])<<8|uint16(content[i+1])))
+		}
+		return string(runes)
+	default:
+		return ""
+	}
+}
+
+// decodeFixedDString decodes a fixed-size dstring field whose final byte
+// holds the used length (including the compression ID byte).
+func decodeFixedDString(field []byte) string {
+	if len(field) == 0 {
+		return ""
+	}
+	used := int(field[len(field)-1])
+	if used == 0 || used > len(field)-1 {
+		return ""
+	}
+	return decodeDString(field[:used])
+}
+
+// parseTimestamp decodes a 12-byte ECMA-167 timestamp.
+func parseTimestamp(data []byte) time.Time {
+	if len(data) < 12 {
+		return time.Time{}
+	}
+	typeAndTZ := binary.LittleEndian.Uint16(data[0:2])
+	year := int(int16(binary.LittleEndian.Uint16(data[2:4])))
+	month := int(data[4])
+	day := int(data[5])
+	hour := int(data[6])
+	minute := int(data[7])
+	second := int(data[8])
+	if year == 0 || month == 0 || day == 0 {
+		return time.Time{}
+	}
+
+	loc := time.UTC
+	// Bits 0-11 hold the timezone offset in minutes (two's complement);
+	// -2047 means unspecified.
+	if tz := int16(typeAndTZ<<4) >> 4; tz != -2047 && tz != 0 {
+		loc = time.FixedZone("", int(tz)*60)
+	}
+	return time.Date(year, time.Month(month), day, hour, minute, second, 0, loc)
+}
+
+// AnchorVolumeDescriptorPointer locates the main and reserve volume
+// descriptor sequences.
+type AnchorVolumeDescriptorPointer struct {
+	MainVDS    ExtentAD
+	ReserveVDS ExtentAD
+}
+
+func parseAVDP(data []byte) (*AnchorVolumeDescriptorPointer, error) {
+	tag, err := parseTag(data)
+	if err != nil {
+		return nil, err
+	}
+	if tag.ID != TAG_ANCHOR_VOLUME_DESCRIPTOR_PTR {
+		return nil, fmt.Errorf("expected anchor volume descriptor pointer (tag 2), got tag %d", tag.ID)
+	}
+	return &AnchorVolumeDescriptorPointer{
+		MainVDS:    parseExtentAD(data[16:24]),
+		ReserveVDS: parseExtentAD(data[24:32]),
+	}, nil
+}
+
+// PrimaryVolumeDescriptor carries the volume identity (ECMA-167 3/10.1).
+type PrimaryVolumeDescriptor struct {
+	VolumeIdentifier    string
+	VolumeSetIdentifier string
+	RecordingDateTime   time.Time
+}
+
+func parsePVD(data []byte) *PrimaryVolumeDescriptor {
+	return &PrimaryVolumeDescriptor{
+		VolumeIdentifier:    decodeFixedDString(data[24:56]),
+		VolumeSetIdentifier: decodeFixedDString(data[72:200]),
+		RecordingDateTime:   parseTimestamp(data[376:388]),
+	}
+}
+
+// PartitionDescriptor maps a partition number to an absolute extent
+// (ECMA-167 3/10.5).
+type PartitionDescriptor struct {
+	PartitionNumber uint16
+	StartingSector  uint32
+	Length          uint32
+}
+
+func parsePD(data []byte) *PartitionDescriptor {
+	return &PartitionDescriptor{
+		PartitionNumber: binary.LittleEndian.Uint16(data[22:24]),
+		StartingSector:  binary.LittleEndian.Uint32(data[188:192]),
+		Length:          binary.LittleEndian.Uint32(data[192:196]),
+	}
+}
+
+// LogicalVolumeDescriptor carries the logical volume identity, block
+// size, and the file set descriptor location (ECMA-167 3/10.6).
+type LogicalVolumeDescriptor struct {
+	LogicalVolumeIdentifier string
+	LogicalBlockSize        uint32
+	FileSetLocation         LongAD
+}
+
+func parseLVD(data []byte) *LogicalVolumeDescriptor {
+	return &LogicalVolumeDescriptor{
+		LogicalVolumeIdentifier: decodeFixedDString(data[84:212]),
+		LogicalBlockSize:        binary.LittleEndian.Uint32(data[212:216]),
+		FileSetLocation:         parseLongAD(data[248:264]),
+	}
+}
+
+// FileSetDescriptor points at the root directory ICB (ECMA-167 4/14.1).
+type FileSetDescriptor struct {
+	FileSetIdentifier string
+	RootDirectoryICB  LongAD
+}
+
+func parseFSD(data []byte) (*FileSetDescriptor, error) {
+	tag, err := parseTag(data)
+	if err != nil {
+		return nil, err
+	}
+	if tag.ID != TAG_FILE_SET_DESCRIPTOR {
+		return nil, fmt.Errorf("expected file set descriptor (tag 256), got tag %d", tag.ID)
+	}
+	return &FileSetDescriptor{
+		FileSetIdentifier: decodeFixedDString(data[304:336]),
+		RootDirectoryICB:  parseLongAD(data[400:416]),
+	}, nil
+}
+
+// FileEntry is the parsed form of a File Entry or Extended File Entry
+// ICB (ECMA-167 4/14.9, 4/14.17).
+type FileEntry struct {
+	FileType          byte
+	UID               uint32
+	GID               uint32
+	Permissions       uint32
+	InformationLength uint64
+	ModificationTime  time.Time
+	// AllocationType is icbTag flags & 7: 0 short_ad, 1 long_ad,
+	// 3 inline data.
+	AllocationType byte
+	// AllocationData is the raw allocation descriptor area (or inline
+	// file data when AllocationType is 3).
+	AllocationData []byte
+	// Extended reports whether this was an Extended File Entry.
+	Extended bool
+}
+
+func parseFileEntry(data []byte) (*FileEntry, error) {
+	tag, err := parseTag(data)
+	if err != nil {
+		return nil, err
+	}
+	if tag.ID != TAG_FILE_ENTRY && tag.ID != TAG_EXTENDED_FILE_ENTRY {
+		return nil, fmt.Errorf("expected file entry (tag 261/266), got tag %d", tag.ID)
+	}
+	extended := tag.ID == TAG_EXTENDED_FILE_ENTRY
+
+	fe := &FileEntry{
+		FileType:       data[16+11],
+		UID:            binary.LittleEndian.Uint32(data[36:40]),
+		GID:            binary.LittleEndian.Uint32(data[40:44]),
+		Permissions:    binary.LittleEndian.Uint32(data[44:48]),
+		AllocationType: data[16+18] & 0x07,
+		Extended:       extended,
+	}
+	fe.InformationLength = binary.LittleEndian.Uint64(data[56:64])
+
+	var eaLenOff, adLenOff, dataOff int
+	if extended {
+		fe.ModificationTime = parseTimestamp(data[92:104])
+		eaLenOff, adLenOff, dataOff = 208, 212, 216
+	} else {
+		fe.ModificationTime = parseTimestamp(data[84:96])
+		eaLenOff, adLenOff, dataOff = 168, 172, 176
+	}
+
+	eaLen := int(binary.LittleEndian.Uint32(data[eaLenOff : eaLenOff+4]))
+	adLen := int(binary.LittleEndian.Uint32(data[adLenOff : adLenOff+4]))
+	start := dataOff + eaLen
+	if start+adLen > len(data) {
+		return nil, fmt.Errorf("file entry allocation descriptors exceed descriptor size")
+	}
+	fe.AllocationData = data[start : start+adLen]
+	return fe, nil
+}
+
+// FileIdentifier is one directory entry (ECMA-167 4/14.4).
+type FileIdentifier struct {
+	Characteristics byte
+	Name            string
+	ICB             LongAD
+}
+
+// IsDirectory reports whether the entry names a directory.
+func (f *FileIdentifier) IsDirectory() bool { return f.Characteristics&FID_CHAR_DIRECTORY != 0 }
+
+// IsParent reports whether the entry is the parent-directory link.
+func (f *FileIdentifier) IsParent() bool { return f.Characteristics&FID_CHAR_PARENT != 0 }
+
+// IsDeleted reports whether the entry is marked deleted.
+func (f *FileIdentifier) IsDeleted() bool { return f.Characteristics&FID_CHAR_DELETED != 0 }
+
+// parseFileIdentifiers walks a directory's content bytes, decoding each
+// File Identifier Descriptor. Each FID is padded to a 4-byte boundary.
+func parseFileIdentifiers(data []byte) ([]*FileIdentifier, error) {
+	var out []*FileIdentifier
+	offset := 0
+	for offset+38 <= len(data) {
+		tag, err := parseTag(data[offset:])
+		if err != nil {
+			// Zero padding after the last entry.
+			break
+		}
+		if tag.ID != TAG_FILE_IDENTIFIER_DESCRIPTOR {
+			break
+		}
+		fidLen := int(data[offset+19])
+		iuLen := int(binary.LittleEndian.Uint16(data[offset+36 : offset+38]))
+		total := 38 + iuLen + fidLen
+		total = (total + 3) / 4 * 4
+		if offset+total > len(data) {
+			return nil, fmt.Errorf("file identifier descriptor exceeds directory data")
+		}
+
+		nameStart := offset + 38 + iuLen
+		out = append(out, &FileIdentifier{
+			Characteristics: data[offset+18],
+			Name:            decodeDString(data[nameStart : nameStart+fidLen]),
+			ICB:             parseLongAD(data[offset+20 : offset+36]),
+		})
+		offset += total
+	}
+	return out, nil
+}
+
+// shortAD is a short_ad allocation descriptor: 30-bit length plus a
+// logical block within the same partition.
+type shortAD struct {
+	Length       uint32
+	LogicalBlock uint32
+}
+
+func parseShortADs(data []byte) []shortAD {
+	var out []shortAD
+	for off := 0; off+8 <= len(data); off += 8 {
+		length := binary.LittleEndian.Uint32(data[off : off+4])
+		if length&0x3FFFFFFF == 0 {
+			break
+		}
+		// Top two bits: 0 = recorded and allocated; anything else is not
+		// readable content.
+		if length>>30 != 0 {
+			continue
+		}
+		out = append(out, shortAD{
+			Length:       length & 0x3FFFFFFF,
+			LogicalBlock: binary.LittleEndian.Uint32(data[off+4 : off+8]),
+		})
+	}
+	return out
+}
+
+func parseLongADs(data []byte) []LongAD {
+	var out []LongAD
+	for off := 0; off+16 <= len(data); off += 16 {
+		raw := binary.LittleEndian.Uint32(data[off : off+4])
+		if raw&0x3FFFFFFF == 0 {
+			break
+		}
+		if raw>>30 != 0 {
+			continue
+		}
+		out = append(out, parseLongAD(data[off:off+16]))
+	}
+	return out
+}

--- a/pkg/udf/udf.go
+++ b/pkg/udf/udf.go
@@ -1,173 +1,566 @@
+// Package udf implements read support for UDF (ECMA-167 / OSTA UDF)
+// filesystems: volume recognition, volume descriptor sequence parsing,
+// and file system traversal through the file set descriptor and ICB
+// hierarchy. Write support is not yet implemented.
 package udf
 
 import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
 	"github.com/bgrewell/iso-kit/pkg/filesystem"
 	"github.com/bgrewell/iso-kit/pkg/iso9660/info"
 	"github.com/bgrewell/iso-kit/pkg/logging"
 	"github.com/bgrewell/iso-kit/pkg/option"
-	"io"
-	"time"
 )
 
+// ErrWriteUnsupported is returned by all mutation APIs: UDF support is
+// currently read-only.
+var ErrWriteUnsupported = errors.New("UDF write support is not implemented")
+
+// IsUDF scans the Volume Recognition Sequence starting at sector 16 for
+// an NSR descriptor (NSR02 or NSR03), the marker of an ECMA-167 file
+// system. Bridge discs carrying both ISO 9660 and UDF also match.
+func IsUDF(reader io.ReaderAt) bool {
+	var buf [SectorSize]byte
+	for sector := int64(vrsStartSector); sector < vrsStartSector+64; sector++ {
+		if _, err := reader.ReadAt(buf[:], sector*SectorSize); err != nil {
+			return false
+		}
+		id := string(buf[1:6])
+		switch id {
+		case "NSR02", "NSR03":
+			return true
+		case "BEA01", "BOOT2", "CD001", "CDW02", "TEA01":
+			// Part of a recognition sequence; keep scanning. TEA01
+			// terminates it, but an NSR must have appeared before that.
+			if id == "TEA01" {
+				return false
+			}
+		default:
+			return false
+		}
+	}
+	return false
+}
+
+// Open parses a UDF filesystem from the reader.
 func Open(isoReader io.ReaderAt, opts ...option.OpenOption) (*UDF, error) {
-	//TODO implement me
-	panic("implement me")
+	openOptions := &option.OpenOptions{
+		Logger: logging.DefaultLogger(),
+	}
+	for _, opt := range opts {
+		opt(openOptions)
+	}
+	if openOptions.Logger == nil {
+		openOptions.Logger = logging.DefaultLogger()
+	}
+
+	if !IsUDF(isoReader) {
+		return nil, errors.New("no UDF volume recognition sequence found")
+	}
+
+	udf := &UDF{
+		reader: isoReader,
+		logger: openOptions.Logger,
+	}
+	if err := udf.parse(); err != nil {
+		return nil, err
+	}
+	return udf, nil
 }
 
+// Create is not yet supported for UDF filesystems.
 func Create(filename string, opts ...option.CreateOption) (*UDF, error) {
-	//TODO implement me
-	panic("implement me")
+	return nil, ErrWriteUnsupported
 }
 
+// UDF is a read-only view of a UDF filesystem.
 type UDF struct {
+	reader io.ReaderAt
+	logger *logging.Logger
+
+	pvd        *PrimaryVolumeDescriptor
+	lvd        *LogicalVolumeDescriptor
+	partitions map[uint16]*PartitionDescriptor
+	fileSet    *FileSetDescriptor
+	entries    []*filesystem.FileSystemEntry
 }
 
-func (U UDF) RootDirectoryLocation() uint32 {
-	//TODO implement me
-	panic("implement me")
+// readSector reads one 2048-byte sector at the given absolute sector.
+func (u *UDF) readSector(sector uint32) ([]byte, error) {
+	buf := make([]byte, SectorSize)
+	if _, err := u.reader.ReadAt(buf, int64(sector)*SectorSize); err != nil {
+		return nil, fmt.Errorf("failed to read sector %d: %w", sector, err)
+	}
+	return buf, nil
 }
 
-func (U UDF) GetVolumeSetID() string {
-	//TODO implement me
-	panic("implement me")
+// partitionSector translates a logical block within a partition to an
+// absolute sector.
+func (u *UDF) partitionSector(partition uint16, logicalBlock uint32) (uint32, error) {
+	pd, ok := u.partitions[partition]
+	if !ok {
+		return 0, fmt.Errorf("reference to unknown partition %d", partition)
+	}
+	return pd.StartingSector + logicalBlock, nil
 }
 
-func (U UDF) GetPublisherID() string {
-	//TODO implement me
-	panic("implement me")
+// parse walks the anchor, volume descriptor sequence, file set, and
+// directory hierarchy.
+func (u *UDF) parse() error {
+	anchor, err := u.readSector(anchorSector)
+	if err != nil {
+		return fmt.Errorf("failed to read anchor volume descriptor pointer: %w", err)
+	}
+	avdp, err := parseAVDP(anchor)
+	if err != nil {
+		return err
+	}
+
+	// Walk the main VDS, falling back to the reserve on error.
+	if err := u.parseVDS(avdp.MainVDS); err != nil {
+		u.logger.Debug("Main volume descriptor sequence unusable, trying reserve", "error", err)
+		if rerr := u.parseVDS(avdp.ReserveVDS); rerr != nil {
+			return fmt.Errorf("failed to parse volume descriptor sequence: %w", err)
+		}
+	}
+	if u.lvd == nil {
+		return errors.New("no logical volume descriptor found")
+	}
+	if len(u.partitions) == 0 {
+		return errors.New("no partition descriptor found")
+	}
+	if u.lvd.LogicalBlockSize != SectorSize {
+		return fmt.Errorf("unsupported UDF logical block size %d", u.lvd.LogicalBlockSize)
+	}
+
+	// File Set Descriptor via the LVD's contents-use long_ad.
+	fsdSector, err := u.partitionSector(u.lvd.FileSetLocation.Partition, u.lvd.FileSetLocation.LogicalBlock)
+	if err != nil {
+		return err
+	}
+	fsdData, err := u.readSector(fsdSector)
+	if err != nil {
+		return err
+	}
+	u.fileSet, err = parseFSD(fsdData)
+	if err != nil {
+		return fmt.Errorf("failed to parse file set descriptor: %w", err)
+	}
+
+	// Walk the directory hierarchy from the root ICB.
+	return u.walkDirectory(u.fileSet.RootDirectoryICB, "", 0)
 }
 
-func (U UDF) GetDataPreparerID() string {
-	//TODO implement me
-	panic("implement me")
+// parseVDS walks a volume descriptor sequence extent.
+func (u *UDF) parseVDS(extent ExtentAD) error {
+	if extent.Length == 0 {
+		return errors.New("empty volume descriptor sequence extent")
+	}
+	u.partitions = map[uint16]*PartitionDescriptor{}
+	sectors := (extent.Length + SectorSize - 1) / SectorSize
+	for i := uint32(0); i < sectors; i++ {
+		data, err := u.readSector(extent.Location + i)
+		if err != nil {
+			return err
+		}
+		tag, err := parseTag(data)
+		if err != nil {
+			return err
+		}
+		switch tag.ID {
+		case TAG_PRIMARY_VOLUME_DESCRIPTOR:
+			u.pvd = parsePVD(data)
+		case TAG_PARTITION_DESCRIPTOR:
+			pd := parsePD(data)
+			u.partitions[pd.PartitionNumber] = pd
+		case TAG_LOGICAL_VOLUME_DESCRIPTOR:
+			u.lvd = parseLVD(data)
+		case TAG_TERMINATING_DESCRIPTOR:
+			return nil
+		}
+	}
+	return nil
 }
 
-func (U UDF) GetApplicationID() string {
-	//TODO implement me
-	panic("implement me")
+// readICB reads and parses the File Entry at an ICB address.
+func (u *UDF) readICB(icb LongAD) (*FileEntry, error) {
+	sector, err := u.partitionSector(icb.Partition, icb.LogicalBlock)
+	if err != nil {
+		return nil, err
+	}
+	data, err := u.readSector(sector)
+	if err != nil {
+		return nil, err
+	}
+	return parseFileEntry(data)
 }
 
-func (U UDF) GetCopyrightID() string {
-	//TODO implement me
-	panic("implement me")
+// contentSegments converts a file entry's allocation descriptors into
+// absolute extent segments.
+func (u *UDF) contentSegments(fe *FileEntry, icbPartition uint16) ([]filesystem.ExtentSegment, error) {
+	var segments []filesystem.ExtentSegment
+	switch fe.AllocationType {
+	case 0: // short_ad: blocks within the ICB's own partition
+		for _, ad := range parseShortADs(fe.AllocationData) {
+			sector, err := u.partitionSector(icbPartition, ad.LogicalBlock)
+			if err != nil {
+				return nil, err
+			}
+			segments = append(segments, filesystem.ExtentSegment{Location: sector, Size: ad.Length})
+		}
+	case 1: // long_ad
+		for _, ad := range parseLongADs(fe.AllocationData) {
+			sector, err := u.partitionSector(ad.Partition, ad.LogicalBlock)
+			if err != nil {
+				return nil, err
+			}
+			segments = append(segments, filesystem.ExtentSegment{Location: sector, Size: ad.Length})
+		}
+	case 3: // inline data in the file entry
+		return nil, nil
+	default:
+		return nil, fmt.Errorf("unsupported allocation descriptor type %d", fe.AllocationType)
+	}
+	return segments, nil
 }
 
-func (U UDF) GetAbstractID() string {
-	//TODO implement me
-	panic("implement me")
+// readContent returns a reader over a file entry's content along with
+// its size.
+func (u *UDF) readContent(fe *FileEntry, icbPartition uint16) (io.ReaderAt, uint64, error) {
+	if fe.AllocationType == 3 {
+		data := fe.AllocationData
+		if uint64(len(data)) > fe.InformationLength {
+			data = data[:fe.InformationLength]
+		}
+		return &sliceReaderAt{data}, uint64(len(data)), nil
+	}
+	segments, err := u.contentSegments(fe, icbPartition)
+	if err != nil {
+		return nil, 0, err
+	}
+	reader := filesystem.NewMultiExtentReader(u.reader, SectorSize, segments)
+	size := uint64(reader.TotalSize())
+	if size > fe.InformationLength {
+		size = fe.InformationLength
+	}
+	return reader, size, nil
 }
 
-func (U UDF) GetBibliographicID() string {
-	//TODO implement me
-	panic("implement me")
+type sliceReaderAt struct{ data []byte }
+
+func (s *sliceReaderAt) ReadAt(p []byte, off int64) (int, error) {
+	if off < 0 || off >= int64(len(s.data)) {
+		return 0, io.EOF
+	}
+	n := copy(p, s.data[off:])
+	if n < len(p) {
+		return n, io.EOF
+	}
+	return n, nil
 }
 
-func (U UDF) GetCreationDateTime() time.Time {
-	//TODO implement me
-	panic("implement me")
+// walkDirectory recursively builds filesystem entries from a directory
+// ICB. depth guards against reference cycles in corrupt images.
+func (u *UDF) walkDirectory(icb LongAD, parentPath string, depth int) error {
+	if depth > 64 {
+		return errors.New("directory hierarchy too deep (possible cycle)")
+	}
+	fe, err := u.readICB(icb)
+	if err != nil {
+		return err
+	}
+	if fe.FileType != FILE_TYPE_DIRECTORY {
+		return fmt.Errorf("ICB at %d:%d is not a directory", icb.Partition, icb.LogicalBlock)
+	}
+
+	// Directory content: the sequence of file identifier descriptors.
+	reader, size, err := u.readContent(fe, icb.Partition)
+	if err != nil {
+		return err
+	}
+	dirData := make([]byte, size)
+	if size > 0 {
+		if _, err := reader.ReadAt(dirData, 0); err != nil && err != io.EOF {
+			return fmt.Errorf("failed to read directory content: %w", err)
+		}
+	}
+	fids, err := parseFileIdentifiers(dirData)
+	if err != nil {
+		return err
+	}
+
+	for _, fid := range fids {
+		if fid.IsParent() || fid.IsDeleted() || fid.Name == "" {
+			continue
+		}
+		childPath := parentPath + "/" + fid.Name
+
+		childFE, err := u.readICB(fid.ICB)
+		if err != nil {
+			u.logger.Debug("Skipping unreadable ICB", "path", childPath, "error", err)
+			continue
+		}
+
+		mode := os.FileMode(posixPermsFromUDF(childFE.Permissions))
+		uid, gid := childFE.UID, childFE.GID
+		modTime := childFE.ModificationTime
+
+		if fid.IsDirectory() {
+			entry := filesystem.NewFileSystemEntry(
+				fid.Name, childPath, true, 0, 0, &uid, &gid,
+				mode|os.ModeDir, modTime, modTime, nil, nil,
+			)
+			u.entries = append(u.entries, entry)
+			if err := u.walkDirectory(fid.ICB, childPath, depth+1); err != nil {
+				return err
+			}
+			continue
+		}
+
+		contentReader, size, err := u.readContent(childFE, fid.ICB.Partition)
+		if err != nil {
+			return fmt.Errorf("failed to resolve content of %s: %w", childPath, err)
+		}
+		entry := filesystem.NewFileSystemEntry(
+			fid.Name, childPath, false, size, 0, &uid, &gid,
+			mode, modTime, modTime, nil, contentReader,
+		)
+		if childFE.FileType == FILE_TYPE_SYMLINK {
+			// Symlink targets are path component sequences in the file
+			// content; decode best-effort.
+			raw := make([]byte, size)
+			if _, err := contentReader.ReadAt(raw, 0); err == nil || err == io.EOF {
+				entry.SymlinkTarget = decodePathComponents(raw)
+			}
+		}
+		u.entries = append(u.entries, entry)
+	}
+	return nil
 }
 
-func (U UDF) GetModificationDateTime() time.Time {
-	//TODO implement me
-	panic("implement me")
+// posixPermsFromUDF converts ECMA-167 file entry permissions (5 bits per
+// class: execute, write, read, chattr, delete) into POSIX rwx bits.
+func posixPermsFromUDF(perms uint32) uint32 {
+	var mode uint32
+	// Other: bits 0-4, group: 5-9, owner: 10-14.
+	if perms&0x0001 != 0 {
+		mode |= 0o001
+	}
+	if perms&0x0002 != 0 {
+		mode |= 0o002
+	}
+	if perms&0x0004 != 0 {
+		mode |= 0o004
+	}
+	if perms&0x0020 != 0 {
+		mode |= 0o010
+	}
+	if perms&0x0040 != 0 {
+		mode |= 0o020
+	}
+	if perms&0x0080 != 0 {
+		mode |= 0o040
+	}
+	if perms&0x0400 != 0 {
+		mode |= 0o100
+	}
+	if perms&0x0800 != 0 {
+		mode |= 0o200
+	}
+	if perms&0x1000 != 0 {
+		mode |= 0o400
+	}
+	return mode
 }
 
-func (U UDF) GetExpirationDateTime() time.Time {
-	//TODO implement me
-	panic("implement me")
+// decodePathComponents decodes an ECMA-167 4/14.16 path component
+// sequence into a slash-separated path.
+func decodePathComponents(data []byte) string {
+	var parts []string
+	offset := 0
+	prefix := ""
+	for offset+4 <= len(data) {
+		componentType := data[offset]
+		length := int(data[offset+1])
+		if offset+4+length > len(data) {
+			break
+		}
+		content := data[offset+4 : offset+4+length]
+		switch componentType {
+		case 2: // root
+			prefix = "/"
+		case 3: // parent
+			parts = append(parts, "..")
+		case 4: // current
+			parts = append(parts, ".")
+		case 5: // named component
+			parts = append(parts, decodeDString(content))
+		}
+		offset += 4 + length
+	}
+	return prefix + strings.Join(parts, "/")
 }
 
-func (U UDF) GetEffectiveDateTime() time.Time {
-	//TODO implement me
-	panic("implement me")
+// --- ISO interface implementation (read-only) ---
+
+func (u *UDF) GetVolumeID() string {
+	if u.lvd != nil && u.lvd.LogicalVolumeIdentifier != "" {
+		return u.lvd.LogicalVolumeIdentifier
+	}
+	if u.pvd != nil {
+		return u.pvd.VolumeIdentifier
+	}
+	return ""
 }
 
-func (U UDF) HasJoliet() bool {
-	//TODO implement me
-	panic("implement me")
+func (u *UDF) GetSystemID() string { return "" }
+
+func (u *UDF) GetVolumeSetID() string {
+	if u.pvd != nil {
+		return u.pvd.VolumeSetIdentifier
+	}
+	return ""
 }
 
-func (U UDF) HasRockRidge() bool {
-	//TODO implement me
-	panic("implement me")
+func (u *UDF) GetPublisherID() string     { return "" }
+func (u *UDF) GetDataPreparerID() string  { return "" }
+func (u *UDF) GetApplicationID() string   { return "" }
+func (u *UDF) GetCopyrightID() string     { return "" }
+func (u *UDF) GetAbstractID() string      { return "" }
+func (u *UDF) GetBibliographicID() string { return "" }
+
+func (u *UDF) GetCreationDateTime() time.Time {
+	if u.pvd != nil {
+		return u.pvd.RecordingDateTime
+	}
+	return time.Time{}
 }
 
-func (U UDF) HasElTorito() bool {
-	//TODO implement me
-	panic("implement me")
+func (u *UDF) GetModificationDateTime() time.Time { return u.GetCreationDateTime() }
+func (u *UDF) GetExpirationDateTime() time.Time   { return time.Time{} }
+func (u *UDF) GetEffectiveDateTime() time.Time    { return time.Time{} }
+
+func (u *UDF) GetVolumeSize() uint32 {
+	var total uint32
+	for _, pd := range u.partitions {
+		if end := pd.StartingSector + pd.Length; end > total {
+			total = end
+		}
+	}
+	return total
 }
 
-func (U UDF) GetVolumeID() string {
-	//TODO implement me
-	panic("implement me")
+func (u *UDF) RootDirectoryLocation() uint32 {
+	if u.fileSet == nil {
+		return 0
+	}
+	sector, err := u.partitionSector(u.fileSet.RootDirectoryICB.Partition, u.fileSet.RootDirectoryICB.LogicalBlock)
+	if err != nil {
+		return 0
+	}
+	return sector
 }
 
-func (U UDF) GetSystemID() string {
-	//TODO implement me
-	panic("implement me")
+func (u *UDF) HasJoliet() bool    { return false }
+func (u *UDF) HasRockRidge() bool { return false }
+func (u *UDF) HasElTorito() bool  { return false }
+
+func (u *UDF) ListBootEntries() ([]*filesystem.FileSystemEntry, error) { return nil, nil }
+
+func (u *UDF) ListFiles() ([]*filesystem.FileSystemEntry, error) {
+	files := make([]*filesystem.FileSystemEntry, 0)
+	for _, e := range u.entries {
+		if !e.IsDir {
+			files = append(files, e)
+		}
+	}
+	return files, nil
 }
 
-func (U UDF) GetVolumeSize() uint32 {
-	//TODO implement me
-	panic("implement me")
+func (u *UDF) ListDirectories() ([]*filesystem.FileSystemEntry, error) {
+	dirs := make([]*filesystem.FileSystemEntry, 0)
+	for _, e := range u.entries {
+		if e.IsDir {
+			dirs = append(dirs, e)
+		}
+	}
+	return dirs, nil
 }
 
-func (U UDF) ListBootEntries() ([]*filesystem.FileSystemEntry, error) {
-	//TODO implement me
-	panic("implement me")
+func (u *UDF) ReadFile(path string) ([]byte, error) {
+	cleaned := "/" + strings.Trim(path, "/")
+	for _, e := range u.entries {
+		if e.FullPath == cleaned && !e.IsDir {
+			return e.GetBytes()
+		}
+	}
+	return nil, fmt.Errorf("file not found: %s", path)
 }
 
-func (U UDF) ListFiles() ([]*filesystem.FileSystemEntry, error) {
-	//TODO implement me
-	panic("implement me")
+func (u *UDF) AddFile(path string, data []byte) error { return ErrWriteUnsupported }
+func (u *UDF) RemoveFile(path string) error           { return ErrWriteUnsupported }
+func (u *UDF) Save(writer io.WriterAt) error          { return ErrWriteUnsupported }
+
+func (u *UDF) CreateDirectories(path string) error {
+	if err := os.MkdirAll(path, 0755); err != nil {
+		return fmt.Errorf("failed to create output directory %s: %w", path, err)
+	}
+	dirs, _ := u.ListDirectories()
+	for _, entry := range dirs {
+		if err := os.MkdirAll(filepath.Join(path, entry.FullPath), 0755); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
-func (U UDF) ListDirectories() ([]*filesystem.FileSystemEntry, error) {
-	//TODO implement me
-	panic("implement me")
+func (u *UDF) Extract(path string) error {
+	if err := u.CreateDirectories(path); err != nil {
+		return err
+	}
+	files, _ := u.ListFiles()
+	for _, entry := range files {
+		outputPath := filepath.Join(path, entry.FullPath)
+		if err := os.MkdirAll(filepath.Dir(outputPath), 0755); err != nil {
+			return err
+		}
+		if entry.IsSymlink() {
+			if err := os.Remove(outputPath); err != nil && !os.IsNotExist(err) {
+				return err
+			}
+			if err := os.Symlink(entry.SymlinkTarget, outputPath); err != nil {
+				return fmt.Errorf("failed to create symlink %s: %w", outputPath, err)
+			}
+			continue
+		}
+		data, err := entry.GetBytes()
+		if err != nil {
+			return err
+		}
+		if err := os.WriteFile(outputPath, data, entry.Mode.Perm()|0400); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
-func (U UDF) ReadFile(path string) ([]byte, error) {
-	//TODO implement me
-	panic("implement me")
+func (u *UDF) SetLogger(logger *logging.Logger) { u.logger = logger }
+func (u *UDF) GetLogger() *logging.Logger       { return u.logger }
+
+func (u *UDF) GetLayout() *info.ISOLayout {
+	return &info.ISOLayout{}
 }
 
-func (U UDF) AddFile(path string, data []byte) error {
-	//TODO implement me
-	panic("implement me")
-}
-
-func (U UDF) RemoveFile(path string) error {
-	//TODO implement me
-	panic("implement me")
-}
-
-func (U UDF) CreateDirectories(path string) error {
-	panic("implement me")
-}
-
-func (U UDF) Extract(path string) error {
-	panic("implement me")
-}
-
-func (U UDF) SetLogger(*logging.Logger) {
-	panic("implement me")
-}
-
-func (U UDF) GetLogger() *logging.Logger {
-	panic("implement me")
-}
-
-func (U *UDF) GetLayout() *info.ISOLayout {
-	panic("implement me")
-}
-
-func (U UDF) Save(writer io.WriterAt) error {
-	//TODO implement me
-	panic("implement me")
-}
-
-func (U UDF) Close() error {
-	//TODO implement me
-	panic("implement me")
+func (u *UDF) Close() error {
+	if f, ok := u.reader.(*os.File); ok {
+		return f.Close()
+	}
+	return nil
 }

--- a/pkg/udf/udf_test.go
+++ b/pkg/udf/udf_test.go
@@ -1,0 +1,289 @@
+package udf
+
+import (
+	"bytes"
+	"encoding/binary"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// buildTestImage constructs a minimal but structurally valid UDF image:
+// VRS, AVDP, a volume descriptor sequence, and a partition holding a
+// file set with a root directory, one file, and a subdirectory with a
+// nested file.
+//
+// Absolute sector map:
+//
+//	16-18   VRS: BEA01, NSR02, TEA01
+//	32-35   VDS: PVD, PD (partition 0 at sector 100), LVD, TD
+//	256     AVDP
+//	100+    partition blocks 0..8 (FSD, ICBs, directory data, content)
+func buildTestImage(t *testing.T) []byte {
+	t.Helper()
+	const partStart = 100
+	image := make([]byte, 300*SectorSize)
+
+	writeVSD := func(sector int, id string) {
+		off := sector * SectorSize
+		image[off] = 0 // structure type
+		copy(image[off+1:], id)
+		image[off+6] = 1 // version
+	}
+	writeVSD(16, "BEA01")
+	writeVSD(17, "NSR02")
+	writeVSD(18, "TEA01")
+
+	// writeTag stamps a descriptor tag over payload already placed at
+	// the sector.
+	writeTag := func(sector int, tagID uint16, tagLocation uint32) {
+		off := sector * SectorSize
+		binary.LittleEndian.PutUint16(image[off:], tagID)
+		binary.LittleEndian.PutUint16(image[off+2:], 2) // version
+		binary.LittleEndian.PutUint32(image[off+12:], tagLocation)
+		var sum byte
+		for i := 0; i < 16; i++ {
+			if i == 4 {
+				continue
+			}
+			sum += image[off+i]
+		}
+		image[off+4] = sum
+	}
+
+	putDString := func(off int, value string, fieldLen int) {
+		image[off] = 8 // compression ID: latin-1
+		copy(image[off+1:], value)
+		image[off+fieldLen-1] = byte(1 + len(value))
+	}
+
+	putLongAD := func(off int, length, logicalBlock uint32, partition uint16) {
+		binary.LittleEndian.PutUint32(image[off:], length)
+		binary.LittleEndian.PutUint32(image[off+4:], logicalBlock)
+		binary.LittleEndian.PutUint16(image[off+8:], partition)
+	}
+
+	// AVDP at 256: main VDS extent = sectors 32-35.
+	{
+		off := 256 * SectorSize
+		binary.LittleEndian.PutUint32(image[off+16:], 4*SectorSize) // length
+		binary.LittleEndian.PutUint32(image[off+20:], 32)           // location
+		writeTag(256, TAG_ANCHOR_VOLUME_DESCRIPTOR_PTR, 256)
+	}
+
+	// PVD at 32.
+	{
+		off := 32 * SectorSize
+		putDString(off+24, "UDFVOL", 32)
+		putDString(off+72, "UDFSET", 128)
+		writeTag(32, TAG_PRIMARY_VOLUME_DESCRIPTOR, 32)
+	}
+
+	// PD at 33: partition 0 at sector 100, 50 blocks.
+	{
+		off := 33 * SectorSize
+		binary.LittleEndian.PutUint16(image[off+22:], 0) // partition number
+		binary.LittleEndian.PutUint32(image[off+188:], partStart)
+		binary.LittleEndian.PutUint32(image[off+192:], 50)
+		writeTag(33, TAG_PARTITION_DESCRIPTOR, 33)
+	}
+
+	// LVD at 34: block size 2048, FSD at partition block 0.
+	{
+		off := 34 * SectorSize
+		putDString(off+84, "UDFLOGVOL", 128)
+		binary.LittleEndian.PutUint32(image[off+212:], SectorSize)
+		putLongAD(off+248, SectorSize, 0, 0)
+		writeTag(34, TAG_LOGICAL_VOLUME_DESCRIPTOR, 34)
+	}
+
+	// TD at 35.
+	writeTag(35, TAG_TERMINATING_DESCRIPTOR, 35)
+
+	// FSD at partition block 0: root ICB at block 1.
+	{
+		off := (partStart + 0) * SectorSize
+		putDString(off+304, "FILESET", 32)
+		putLongAD(off+400, SectorSize, 1, 0)
+		writeTag(partStart+0, TAG_FILE_SET_DESCRIPTOR, 0)
+	}
+
+	// writeFE places a File Entry ICB at a partition block.
+	writeFE := func(block int, fileType byte, infoLength uint64, perms uint32, ads []shortAD) {
+		off := (partStart + block) * SectorSize
+		image[off+16+11] = fileType
+		image[off+16+18] = 0 // short_ad allocation
+		binary.LittleEndian.PutUint32(image[off+36:], 1000)  // uid
+		binary.LittleEndian.PutUint32(image[off+40:], 1000)  // gid
+		binary.LittleEndian.PutUint32(image[off+44:], perms) // permissions
+		binary.LittleEndian.PutUint64(image[off+56:], infoLength)
+		adOff := off + 176
+		binary.LittleEndian.PutUint32(image[off+172:], uint32(8*len(ads)))
+		for _, ad := range ads {
+			binary.LittleEndian.PutUint32(image[adOff:], ad.Length)
+			binary.LittleEndian.PutUint32(image[adOff+4:], ad.LogicalBlock)
+			adOff += 8
+		}
+		writeTag(partStart+block, TAG_FILE_ENTRY, uint32(block))
+	}
+
+	// makeFID encodes a file identifier descriptor; tag stamped later
+	// when the directory data lands in a sector.
+	makeFID := func(name string, characteristics byte, icbBlock uint32) []byte {
+		nameBytes := []byte{}
+		if name != "" {
+			nameBytes = append([]byte{8}, name...)
+		}
+		total := 38 + len(nameBytes)
+		total = (total + 3) / 4 * 4
+		fid := make([]byte, total)
+		binary.LittleEndian.PutUint16(fid[16:], 1) // file version
+		fid[18] = characteristics
+		fid[19] = byte(len(nameBytes))
+		binary.LittleEndian.PutUint32(fid[20:], SectorSize) // ICB length
+		binary.LittleEndian.PutUint32(fid[24:], icbBlock)
+		copy(fid[38:], nameBytes)
+		return fid
+	}
+
+	// stampFIDTags writes directory content into a partition block and
+	// stamps each FID's descriptor tag.
+	writeDirContent := func(block int, fids [][]byte) int {
+		off := (partStart + block) * SectorSize
+		pos := off
+		for _, fid := range fids {
+			copy(image[pos:], fid)
+			// Stamp the tag in place.
+			binary.LittleEndian.PutUint16(image[pos:], TAG_FILE_IDENTIFIER_DESCRIPTOR)
+			binary.LittleEndian.PutUint16(image[pos+2:], 2)
+			binary.LittleEndian.PutUint32(image[pos+12:], uint32(block))
+			var sum byte
+			for i := 0; i < 16; i++ {
+				if i == 4 {
+					continue
+				}
+				sum += image[pos+i]
+			}
+			image[pos+4] = sum
+			pos += len(fid)
+		}
+		return pos - off
+	}
+
+	const permsRW = 0x1000 | 0x0800 | 0x0080 | 0x0004 // owner rw, group r, other r
+
+	// Root directory content at block 2.
+	rootFIDs := [][]byte{
+		makeFID("", FID_CHAR_PARENT|FID_CHAR_DIRECTORY, 1),
+		makeFID("hello.txt", 0, 3),
+		makeFID("subdir", FID_CHAR_DIRECTORY, 4),
+	}
+	rootDirLen := writeDirContent(2, rootFIDs)
+	writeFE(1, FILE_TYPE_DIRECTORY, uint64(rootDirLen), permsRW, []shortAD{{Length: uint32(rootDirLen), LogicalBlock: 2}})
+
+	// hello.txt: ICB at block 3, content at block 5.
+	content := []byte("hello from udf\n")
+	copy(image[(partStart+5)*SectorSize:], content)
+	writeFE(3, FILE_TYPE_REGULAR, uint64(len(content)), permsRW, []shortAD{{Length: uint32(len(content)), LogicalBlock: 5}})
+
+	// subdir: ICB at block 4, content at block 6, containing nested.bin
+	// (ICB block 7, content block 8).
+	subFIDs := [][]byte{
+		makeFID("", FID_CHAR_PARENT|FID_CHAR_DIRECTORY, 1),
+		makeFID("nested.bin", 0, 7),
+	}
+	subDirLen := writeDirContent(6, subFIDs)
+	writeFE(4, FILE_TYPE_DIRECTORY, uint64(subDirLen), permsRW, []shortAD{{Length: uint32(subDirLen), LogicalBlock: 6}})
+
+	nested := []byte{0xCA, 0xFE, 0xBA, 0xBE}
+	copy(image[(partStart+8)*SectorSize:], nested)
+	writeFE(7, FILE_TYPE_REGULAR, uint64(len(nested)), permsRW, []shortAD{{Length: uint32(len(nested)), LogicalBlock: 8}})
+
+	return image
+}
+
+func TestIsUDF(t *testing.T) {
+	image := buildTestImage(t)
+	require.True(t, IsUDF(bytes.NewReader(image)))
+
+	// A plain ISO 9660 style VRS without NSR is not UDF.
+	notUDF := make([]byte, 20*SectorSize)
+	copy(notUDF[16*SectorSize+1:], "CD001")
+	require.False(t, IsUDF(bytes.NewReader(notUDF)))
+
+	require.False(t, IsUDF(bytes.NewReader(make([]byte, 20*SectorSize))))
+}
+
+func TestOpenAndList(t *testing.T) {
+	image := buildTestImage(t)
+
+	u, err := Open(bytes.NewReader(image))
+	require.NoError(t, err)
+
+	require.Equal(t, "UDFLOGVOL", u.GetVolumeID())
+	require.Equal(t, "UDFSET", u.GetVolumeSetID())
+
+	files, err := u.ListFiles()
+	require.NoError(t, err)
+	require.Len(t, files, 2)
+
+	dirs, err := u.ListDirectories()
+	require.NoError(t, err)
+	require.Len(t, dirs, 1)
+	require.Equal(t, "/subdir", dirs[0].FullPath)
+
+	// Ownership and permissions decoded from the ICB.
+	require.NotNil(t, files[0].UID)
+	require.Equal(t, uint32(1000), *files[0].UID)
+	require.Equal(t, os.FileMode(0o644), files[0].Mode.Perm())
+}
+
+func TestReadFile(t *testing.T) {
+	image := buildTestImage(t)
+
+	u, err := Open(bytes.NewReader(image))
+	require.NoError(t, err)
+
+	data, err := u.ReadFile("hello.txt")
+	require.NoError(t, err)
+	require.Equal(t, []byte("hello from udf\n"), data)
+
+	data, err = u.ReadFile("/subdir/nested.bin")
+	require.NoError(t, err)
+	require.Equal(t, []byte{0xCA, 0xFE, 0xBA, 0xBE}, data)
+
+	_, err = u.ReadFile("missing.txt")
+	require.Error(t, err)
+}
+
+func TestExtract(t *testing.T) {
+	image := buildTestImage(t)
+
+	u, err := Open(bytes.NewReader(image))
+	require.NoError(t, err)
+
+	outDir := t.TempDir()
+	require.NoError(t, u.Extract(outDir))
+
+	data, err := os.ReadFile(filepath.Join(outDir, "hello.txt"))
+	require.NoError(t, err)
+	require.Equal(t, []byte("hello from udf\n"), data)
+
+	data, err = os.ReadFile(filepath.Join(outDir, "subdir", "nested.bin"))
+	require.NoError(t, err)
+	require.Equal(t, []byte{0xCA, 0xFE, 0xBA, 0xBE}, data)
+}
+
+func TestWriteUnsupported(t *testing.T) {
+	image := buildTestImage(t)
+	u, err := Open(bytes.NewReader(image))
+	require.NoError(t, err)
+
+	require.ErrorIs(t, u.AddFile("x", nil), ErrWriteUnsupported)
+	require.ErrorIs(t, u.RemoveFile("x"), ErrWriteUnsupported)
+	require.ErrorIs(t, u.Save(nil), ErrWriteUnsupported)
+	_, err = Create("x")
+	require.ErrorIs(t, err, ErrWriteUnsupported)
+}


### PR DESCRIPTION
## Summary

P3 slice: the `udf` package goes from 33 panic stubs to a working **ECMA-167 read implementation**, and pure-UDF images are now actually detected.

### Detection fix
`iso.Open` previously probed sector 256 for the "BEA01" string — but BEA01 lives in the Volume Recognition Sequence at sector 16+, and sector 256 holds the binary AVDP. Pure UDF images could never be detected. `udf.IsUDF` now scans the VRS for an NSR02/NSR03 descriptor; bridge discs still open through the richer ISO 9660 path.

### Read path (ECMA-167)
- Descriptor tags with checksum verification
- AVDP → volume descriptor sequence (PVD, partition descriptor, logical volume descriptor) with reserve-VDS fallback
- File Set Descriptor → root ICB → recursive traversal: FE and EFE ICBs, short_ad / long_ad / inline allocation, FIDs with OSTA compressed unicode names (8-bit and UCS-2)
- File content served through the multi-extent segmented reader from #11 — fragmented files assemble transparently
- Symlink ICBs decode path component sequences; ECMA-167 permission bits map to POSIX modes with uid/gid
- Depth-bounded directory walk guards against cycles in corrupt images

### Interface
Read-only `ISO` implementation: listing, `ReadFile`, `Extract` (with symlink materialization), identity getters. Mutations return `ErrWriteUnsupported` — an honest error instead of the previous panics.

## Test plan
- Tests construct a structurally valid UDF image from scratch (VRS, AVDP, VDS, FSD, nested directory tree) — every descriptor our parser reads is exercised by bytes we control
- Detection positive/negative cases, listing counts, uid/gid/mode decoding, file reads at both levels, extraction to disk, read-only error contract
- Full suite green: `go build`, `go vet`, `go test ./...`
- Note: no UDF authoring tool exists on the dev host (mkudffs/udfinfo absent); verification against a foreign-authored UDF image is a good follow-up for CI