### PR TITLE
Add unit tests across all core packages, fix boot catalog section parsing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    name: Build and test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      # xorriso, fdisk, and parted power the interoperability tests
+      # (Rock Ridge / Joliet / El Torito / hybrid partition verification).
+      # Tests skip gracefully when tools are missing, so this step failing
+      # soft would silently reduce coverage; keep it required.
+      - name: Install interop tools
+        run: sudo apt-get update && sudo apt-get install -y xorriso fdisk parted genisoimage
+
+      - name: Check formatting
+        run: |
+          unformatted=$(gofmt -l ./pkg ./cmd)
+          if [ -n "$unformatted" ]; then
+            echo "gofmt required for:" && echo "$unformatted" && exit 1
+          fi
+
+      - name: Build
+        run: go build ./...
+
+      - name: Vet
+        run: go vet ./...
+
+      - name: Test
+        run: go test -race -count=1 ./...
+
+      - name: Coverage
+        run: go test -count=1 -coverprofile=coverage.out -coverpkg=./... ./... && go tool cover -func=coverage.out | tail -1

--- a/README.md
+++ b/README.md
@@ -1,84 +1,109 @@
 # iso-kit
 
+[![CI](https://github.com/bgrewell/iso-kit/actions/workflows/ci.yml/badge.svg)](https://github.com/bgrewell/iso-kit/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/bgrewell/iso-kit/graph/badge.svg?token=D15C46IECF)](https://codecov.io/gh/bgrewell/iso-kit)
 
-> **Notice:** This project is in an early development phase and may not yet be fully stable or feature complete. As it evolves, you may encounter significant changes to the API, behavior, and overall functionality.
+**iso-kit** is a Go library for working with ISO 9660 disk images: open existing
+images, modify them, or build new ones from scratch — with Rock Ridge, Joliet,
+El Torito boot, hybrid (USB-bootable) layouts, and read-only UDF support.
 
-**iso-kit** is a Go library designed to simplify working with ISO 9660 disk images. Whether you're creating, extracting, or inspecting ISO files, iso-kit provides a reliable and feature-rich solution with advanced support for key extensions like Rock Ridge and El Torito.
+> **Notice:** The API is pre-1.0 and may still change between releases.
 
-In addition to being a library for developers, **iso-kit** also includes some command line tools for working with ISO
-files that can be installed via the command line using the commands below.
+## Features
 
-#### isoextract
+- **Read**: parse ISO 9660 images including Rock Ridge (POSIX metadata,
+  symlinks), Joliet (Unicode names), El Torito boot catalogs, multi-extent
+  (>4 GiB) files, and path tables. Extract full trees to disk, symlinks
+  included.
+- **Create**: build images from scratch or from a local directory tree.
+  Rock Ridge is written by default; Joliet is opt-in; identifiers can be
+  enforced at ISO 9660 interchange levels 1–3.
+- **Modify**: open an image, add/remove files and directories, and save —
+  existing file content is streamed and relocated, never fully loaded into
+  memory.
+- **Boot**: register BIOS and EFI El Torito boot entries (with isolinux
+  boot-info-table patching), and write hybrid MBR/GPT partition structures so
+  images boot from USB media.
+- **UDF**: read-only support for ECMA-167 / UDF images (listing, reading,
+  extraction).
 
-**isoextract** is a command line tool for extracting files from an ISO image. It can be installed using the following command:
+## Library usage
+
+```go
+import (
+    "os"
+
+    "github.com/bgrewell/iso-kit/pkg/iso9660"
+    "github.com/bgrewell/iso-kit/pkg/option"
+)
+
+// Create an image from scratch.
+img, _ := iso9660.Create("MYVOLUME", option.WithJolietEnabled(true))
+img.AddFile("docs/readme.txt", []byte("hello\n"))
+img.AddLocalDirectory("./payload", "/payload")
+out, _ := os.Create("out.iso")
+img.Save(out)
+
+// Open, modify, save.
+f, _ := os.Open("existing.iso")
+img2, _ := iso9660.Open(f)
+data, _ := img2.ReadFile("some/file.txt")
+img2.AddFile("added.txt", data)
+img2.RemoveFile("obsolete.txt")
+out2, _ := os.Create("modified.iso")
+img2.Save(out2)
+```
+
+Bootable, USB-writable images:
+
+```go
+img.AddBootImage(iso9660.BootImageConfig{
+    Path: "isolinux/isolinux.bin", Platform: boot.BIOS,
+    Emulation: boot.NoEmulation, LoadSize: 4, BootInfoTable: true,
+})
+img.AddBootImage(iso9660.BootImageConfig{
+    Path: "EFI/BOOT/efiboot.img", Platform: boot.EFI, Emulation: boot.NoEmulation,
+})
+img.SetHybridBoot(iso9660.HybridBootConfig{
+    MBRBootCode:      isohdpfx, // e.g. syslinux isohdpfx.bin
+    EFIBootImagePath: "EFI/BOOT/efiboot.img",
+    AddGPT:           true,
+})
+```
+
+## Command line tools
 
 ```bash
 go install github.com/bgrewell/iso-kit/cmd/isoextract@latest
+go install github.com/bgrewell/iso-kit/cmd/isocreate@latest
+go install github.com/bgrewell/iso-kit/cmd/isoview@latest
 ```
 
-*note: you may need to ensure that `$GOBIN` is in your `$PATH` you can do that by adding `export PATH=$PATH:$(go env GOPATH)/bin`
-to your shell profile.*
+- **isoextract** — extract files and boot images from an ISO
+- **isocreate** — build an ISO from a directory tree
+  (`isocreate -V MYVOL -o out.iso ./srcdir`, plus `--bios-boot`,
+  `--efi-boot`, `--isohybrid`, `--gpt`, `--joliet`, `--level`)
+- **isoview** — inspect image structure and layout
 
+*Note: ensure `$GOBIN` is in your `$PATH`
+(`export PATH=$PATH:$(go env GOPATH)/bin`).*
 
-## Project Goals
+## Format support
 
-The primary goals of **iso-kit** include:
+| Capability | Read | Write |
+|---|---|---|
+| ISO 9660 | ✅ | ✅ |
+| Rock Ridge (SUSP/RRIP: SP, CE, ER, PX, NM, SL, TF, PN, CL, PL, RE) | ✅ | ✅ |
+| Joliet (UCS-2 hierarchy) | ✅ | ✅ |
+| El Torito (multi-boot, BIOS + EFI sections, boot info table) | ✅ | ✅ |
+| Hybrid MBR / GPT (USB boot) | ✅ | ✅ |
+| Multi-extent files (>4 GiB) | ✅ | ❌ |
+| UDF (ECMA-167) | ✅ | ❌ |
 
-1. **Comprehensive ISO Handling**: 
-   - Support for creating, extracting, and modifying ISO 9660 disk images.
-   - Advanced parsing and inspection tools for ISO metadata and structure.
+Interoperability is verified in CI against xorriso (Rock Ridge, Joliet,
+El Torito reporting) and util-linux fdisk / parted (hybrid partition tables).
 
-2. **Extension Support**:
-   - Full compatibility with Rock Ridge extensions and Joliet for enhanced file attributes.
-   - Support for El Torito extensions for handling bootable images.
+## Roadmap
 
-3. **Simplicity and Usability**:
-   - An intuitive API designed for developers.
-   - Detailed documentation and examples to accelerate integration.
-
-4. **Performance and Reliability**:
-   - Efficient handling of large ISO files.
-   - Robust error handling and validation for edge cases.
-
-5. **Future-Proof Design**:
-   - Modular and extensible architecture to accommodate future enhancements.
-   - Potential for additional features like UDF support or hybrid ISO handling.
-
----
-
-This library is ideal for developers building tools for ISO manipulation, virtual disk creation, or custom filesystem operations.
-
-Stay tuned for updates as we continue to expand functionality and refine the library!
-
-## ISO9660 Details
-
-### Support
-
- - [x] ISO 9660
- - [x] El Torito
- - [x] Joliet
- - [x] System Use Sharing Protocol (SUSP)
-   - [x] Rock Ridge
-   - [ ] CE (SUSP 5.1):
-   - [ ] PD (SUSP 5.2):
-   - [ ] SP (SUSP 5.3):
-   - [ ] ST (SUSP 5.4):
-   - [ ] ER (SUSP 5.5):
-   - [ ] ES (SUSP 5.6):
-
-### Current Limitations
-
- - **Extract Only** - Currently this library only supports extraction of files and boot images. Support for creating ISOs is coming soon.
- - **Rock Ridge** - While Rock Ridge is supported, some features may not be fully implemented. Please report any issues you encounter.
- - **Joliet** - Joliet is supported, but some edge cases may not be fully implemented. Please report any issues you encounter.
- - **El Torito** - El Torito is supported, but some edge cases may not be fully implemented. Please report any issues you encounter.
- - **Validation** - This library has not been extensively tested and does not currently have any unit or functional tests so again, report any issues you encouter.
-
-## Test Coverage
-
-<img src="https://codecov.io/gh/bgrewell/iso-kit/graphs/sunburst.svg?token=D15C46IECF"/>
-
-## Development Notes
-
- - **Comments** - Comments have been added to structs and other parts of the code where it makes sense to document the purpose of fields including details such as encoding.
+See [docs/ROADMAP.md](docs/ROADMAP.md) for the detailed phase plan and
+remaining work (UDF write support, multi-extent write, and more).

--- a/cmd/isocreate/main.go
+++ b/cmd/isocreate/main.go
@@ -1,38 +1,134 @@
 package main
 
 import (
-	"github.com/bgrewell/iso-kit"
-	"github.com/bgrewell/iso-kit/pkg/option"
+	"fmt"
 	"os"
+	"strings"
+
+	"github.com/bgrewell/iso-kit/pkg/iso9660"
+	"github.com/bgrewell/iso-kit/pkg/iso9660/boot"
+	"github.com/bgrewell/iso-kit/pkg/option"
+	"github.com/bgrewell/iso-kit/pkg/version"
+	"github.com/bgrewell/usage"
 )
 
+func fail(u *usage.Usage, err error) {
+	u.PrintError(err)
+	os.Exit(1)
+}
+
 func main() {
-
-	name := "ubuntu-test-iso"
-	source := "/tmp/ubuntu-iso"
-	dest := "/tmp/created-ubuntu.iso"
-	_ = source //TODO: this will be passed in via an 'AddDir' command
-	_ = dest
-
-	// Use values from the real ISO to simplify testing
-	name = "Ubuntu-Server 24.04.1 LTS amd64"
-	preparer := "XORRISO-1.5.4 2021.01.30.150001, LIBISOBURN-1.5.4, LIBISOFS-1.5.4, LIBBURN-1.5.4"
-
-	i, err := iso.Create(name,
-		option.WithPreparerID(preparer),
+	u := usage.NewUsage(
+		usage.WithApplicationVersion(version.Version()),
+		usage.WithApplicationBranch(version.Branch()),
+		usage.WithApplicationBuildDate(version.Date()),
+		usage.WithApplicationCommitHash(version.Revision()),
+		usage.WithApplicationName("isocreate"),
+		usage.WithApplicationDescription("isocreate builds ISO9660 images from a directory tree, with support for Rock Ridge, Joliet, El Torito boot entries, and hybrid (USB-bootable) layouts."),
 	)
-	if err != nil {
-		panic(err)
+
+	help := u.AddBooleanOption("h", "help", false, "Show this help message", "optional", nil)
+
+	volumeID := u.AddStringOption("V", "volid", "ISOIMAGE", "Volume identifier", "", nil)
+	preparer := u.AddStringOption("p", "preparer", "", "Data preparer identifier", "", nil)
+	output := u.AddStringOption("o", "output", "", "Output ISO file path (required)", "", nil)
+
+	rockRidge := u.AddBooleanOption("rr", "rockridge", true, "Write Rock Ridge (POSIX metadata) extensions", "", nil)
+	joliet := u.AddBooleanOption("J", "joliet", false, "Write a Joliet (Windows Unicode names) hierarchy", "", nil)
+	level := u.AddIntegerOption("l", "level", 0, "ISO9660 interchange level to enforce (1, 2, or 3; 0 = relaxed)", "", nil)
+
+	biosBoot := u.AddStringOption("b", "bios-boot", "", "Path (inside the image) of the BIOS boot image (El Torito, no emulation, 4-sector load, boot info table)", "", nil)
+	efiBoot := u.AddStringOption("e", "efi-boot", "", "Path (inside the image) of the EFI boot image (El Torito EFI platform entry)", "", nil)
+	hybrid := u.AddBooleanOption("H", "isohybrid", false, "Write hybrid MBR partition structures for USB boot", "", nil)
+	hybridMBR := u.AddStringOption("m", "isohybrid-mbr", "", "File containing MBR boot code for the hybrid layout (e.g. isohdpfx.bin)", "", nil)
+	gpt := u.AddBooleanOption("g", "gpt", false, "Add a GPT with an EFI System Partition entry (requires --efi-boot)", "", nil)
+
+	sourceDir := u.AddArgument(1, "source-dir", "Directory tree to build the image from", "")
+
+	if !u.Parse() {
+		fail(u, fmt.Errorf("failed to parse arguments"))
+	}
+	if *help {
+		u.PrintUsage()
+		os.Exit(0)
+	}
+	if *sourceDir == "" {
+		fail(u, fmt.Errorf("source directory is required"))
+	}
+	if *output == "" {
+		fail(u, fmt.Errorf("output path is required (-o)"))
+	}
+	if *gpt && *efiBoot == "" {
+		fail(u, fmt.Errorf("--gpt requires --efi-boot"))
 	}
 
-	f, err := os.Create(dest)
-	if err != nil {
-		panic(err)
+	opts := []option.CreateOption{
+		option.WithCreateRockRidgeEnabled(*rockRidge),
+		option.WithJolietEnabled(*joliet),
+		option.WithInterchangeLevel(*level),
+	}
+	if *preparer != "" {
+		opts = append(opts, option.WithPreparerID(*preparer))
 	}
 
-	err = i.Save(f)
+	iso, err := iso9660.Create(*volumeID, opts...)
 	if err != nil {
-		panic(err)
+		fail(u, fmt.Errorf("failed to create image: %w", err))
 	}
 
+	if err := iso.AddLocalDirectory(*sourceDir, "/"); err != nil {
+		fail(u, fmt.Errorf("failed to import %s: %w", *sourceDir, err))
+	}
+
+	if *biosBoot != "" {
+		err := iso.AddBootImage(iso9660.BootImageConfig{
+			Path:          strings.TrimPrefix(*biosBoot, "/"),
+			Platform:      boot.BIOS,
+			Emulation:     boot.NoEmulation,
+			LoadSize:      4,
+			BootInfoTable: true,
+		})
+		if err != nil {
+			fail(u, fmt.Errorf("failed to add BIOS boot image: %w", err))
+		}
+	}
+	if *efiBoot != "" {
+		err := iso.AddBootImage(iso9660.BootImageConfig{
+			Path:      strings.TrimPrefix(*efiBoot, "/"),
+			Platform:  boot.EFI,
+			Emulation: boot.NoEmulation,
+		})
+		if err != nil {
+			fail(u, fmt.Errorf("failed to add EFI boot image: %w", err))
+		}
+	}
+
+	if *hybrid || *gpt || *hybridMBR != "" {
+		cfg := iso9660.HybridBootConfig{
+			EFIBootImagePath: strings.TrimPrefix(*efiBoot, "/"),
+			AddGPT:           *gpt,
+		}
+		if *hybridMBR != "" {
+			code, err := os.ReadFile(*hybridMBR)
+			if err != nil {
+				fail(u, fmt.Errorf("failed to read MBR boot code: %w", err))
+			}
+			cfg.MBRBootCode = code
+		}
+		if err := iso.SetHybridBoot(cfg); err != nil {
+			fail(u, fmt.Errorf("failed to configure hybrid boot: %w", err))
+		}
+	}
+
+	out, err := os.Create(*output)
+	if err != nil {
+		fail(u, fmt.Errorf("failed to create output file: %w", err))
+	}
+	defer out.Close()
+
+	if err := iso.Save(out); err != nil {
+		fail(u, fmt.Errorf("failed to write image: %w", err))
+	}
+
+	fmt.Printf("Wrote %s (volume %q, %d sectors)\n", *output, *volumeID, iso.GetVolumeSize())
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,9 +1,9 @@
 package main
 
 import (
-  "fmt"
+	"fmt"
 )
 
 func main() {
-  fmt.Println("main template")
+	fmt.Println("main template")
 }

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -201,9 +201,13 @@ Goal: UDF support, USB-bootable hybrid ISOs, production CLI, comprehensive testi
     GPT mode writes a protective MBR + GPT with the EFI System Partition
     and a backup GPT appended after the ISO data
   - Verified with fdisk and parted: GPT disklabel and ESP recognized
-- [ ] Rebuild `isocreate` CLI with proper argument parsing
+- [x] Rebuild `isocreate` CLI with proper argument parsing
+  - Volume/preparer identity, Rock Ridge/Joliet/interchange-level toggles,
+    BIOS + EFI boot entries, isohybrid MBR/GPT flags
 - [ ] Comprehensive unit tests (directory, parser, pathtable, extensions, eltorito)
-- [ ] CI pipeline (GitHub Actions) + README update
+- [x] CI pipeline (GitHub Actions) + README update
+  - Build, vet, gofmt gate, race-enabled tests with xorriso/fdisk/parted
+    installed so interop tests run, coverage summary
 - [ ] Split `VolumeDescriptor` interface into base + filesystem-aware sub-interface
 
 ## Architectural Concerns

--- a/pkg/filesystem/entry_test.go
+++ b/pkg/filesystem/entry_test.go
@@ -1,0 +1,110 @@
+package filesystem
+
+import (
+	"bytes"
+	"crypto/md5"
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+import "github.com/stretchr/testify/require"
+
+func newTestEntry(t *testing.T, content []byte) *FileSystemEntry {
+	t.Helper()
+	// Content at sector 2 of a backing image; entry addressed by location.
+	backing := make([]byte, 4*2048)
+	copy(backing[2*2048:], content)
+	return NewFileSystemEntry(
+		"file.txt", "/file.txt", false, uint64(len(content)), 2,
+		nil, nil, 0o644,
+		time.Now(), time.Now(), nil, bytes.NewReader(backing),
+	)
+}
+
+func TestGetBytes(t *testing.T) {
+	content := []byte("some file content")
+	entry := newTestEntry(t, content)
+
+	data, err := entry.GetBytes()
+	require.NoError(t, err)
+	require.Equal(t, content, data)
+}
+
+func TestGetBytesDirectoryFails(t *testing.T) {
+	dir := NewFileSystemEntry("d", "/d", true, 0, 0, nil, nil, 0o755, time.Now(), time.Now(), nil, nil)
+	_, err := dir.GetBytes()
+	require.Error(t, err)
+	_, err = dir.GetMD5()
+	require.Error(t, err)
+	_, err = dir.GetSHA256()
+	require.Error(t, err)
+}
+
+func TestHashes(t *testing.T) {
+	content := []byte("hash me")
+	entry := newTestEntry(t, content)
+
+	md5sum, err := entry.GetMD5()
+	require.NoError(t, err)
+	want := md5.Sum(content)
+	require.Equal(t, hex.EncodeToString(want[:]), md5sum)
+
+	shasum, err := entry.GetSHA256()
+	require.NoError(t, err)
+	wantSHA := sha256.Sum256(content)
+	require.Equal(t, hex.EncodeToString(wantSHA[:]), shasum)
+}
+
+func TestExtractToDisk(t *testing.T) {
+	content := []byte("extract me")
+	entry := newTestEntry(t, content)
+
+	outDir := t.TempDir()
+	require.NoError(t, entry.ExtractToDisk(outDir))
+
+	data, err := os.ReadFile(filepath.Join(outDir, "file.txt"))
+	require.NoError(t, err)
+	require.Equal(t, content, data)
+
+	fi, err := os.Stat(filepath.Join(outDir, "file.txt"))
+	require.NoError(t, err)
+	require.Equal(t, os.FileMode(0o644), fi.Mode().Perm())
+}
+
+func TestExtractToDiskDirectory(t *testing.T) {
+	dir := NewFileSystemEntry("sub", "/nested/sub", true, 0, 0, nil, nil, 0o755, time.Now(), time.Now(), nil, nil)
+	outDir := t.TempDir()
+	require.NoError(t, dir.ExtractToDisk(outDir))
+	fi, err := os.Stat(filepath.Join(outDir, "nested", "sub"))
+	require.NoError(t, err)
+	require.True(t, fi.IsDir())
+}
+
+func TestIsSymlink(t *testing.T) {
+	entry := newTestEntry(t, []byte("x"))
+	require.False(t, entry.IsSymlink())
+	entry.SymlinkTarget = "somewhere"
+	require.True(t, entry.IsSymlink())
+}
+
+func TestMultiExtentReaderSingleSegment(t *testing.T) {
+	backing := make([]byte, 3*2048)
+	copy(backing[2048:], "single segment content")
+
+	r := NewMultiExtentReader(bytes.NewReader(backing), 2048, []ExtentSegment{{Location: 1, Size: 22}})
+	require.Equal(t, int64(22), r.TotalSize())
+
+	buf := make([]byte, 22)
+	n, err := r.ReadAt(buf, 0)
+	require.NoError(t, err)
+	require.Equal(t, 22, n)
+	require.Equal(t, "single segment content", string(buf))
+
+	// Negative offsets error.
+	_, err = r.ReadAt(buf, -1)
+	require.Error(t, err)
+}

--- a/pkg/helpers/strings_test.go
+++ b/pkg/helpers/strings_test.go
@@ -1,0 +1,22 @@
+package helpers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPadString(t *testing.T) {
+	// Shorter strings pad with the ISO 9660 filler (space).
+	padded := PadString("ABC", 8)
+	require.Equal(t, []byte("ABC     "), padded)
+
+	// Exact fit passes through.
+	require.Equal(t, []byte("ABCD"), PadString("ABCD", 4))
+
+	// Longer strings truncate to the field.
+	require.Equal(t, []byte("AB"), PadString("ABCD", 2))
+
+	// Zero-length fields are empty.
+	require.Empty(t, PadString("ABC", 0))
+}

--- a/pkg/iso9660/api_test.go
+++ b/pkg/iso9660/api_test.go
@@ -1,0 +1,184 @@
+package iso9660
+
+import (
+	"os"
+	"testing"
+
+	"github.com/bgrewell/iso-kit/pkg/option"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCreatedImageGetters exercises the descriptor-backed getters on a
+// freshly created (never saved) image — historically a nil-panic minefield.
+func TestCreatedImageGetters(t *testing.T) {
+	iso, err := Create("GETTERS")
+	require.NoError(t, err)
+
+	require.Equal(t, "GETTERS", iso.GetVolumeID())
+	require.NotEmpty(t, iso.GetDataPreparerID())
+	require.Empty(t, iso.GetPublisherID())
+	require.Empty(t, iso.GetApplicationID())
+	require.Empty(t, iso.GetCopyrightID())
+	require.Empty(t, iso.GetAbstractID())
+	require.Empty(t, iso.GetBibliographicID())
+	require.Empty(t, iso.GetSystemID())
+	require.Empty(t, iso.GetVolumeSetID())
+	require.False(t, iso.GetCreationDateTime().IsZero())
+	require.False(t, iso.GetModificationDateTime().IsZero())
+	require.True(t, iso.GetExpirationDateTime().IsZero())
+	require.True(t, iso.GetEffectiveDateTime().IsZero())
+	require.Zero(t, iso.GetVolumeSize(), "unsaved image has no assigned size")
+	require.False(t, iso.HasJoliet())
+	require.False(t, iso.HasRockRidge(), "no parsed records yet")
+	require.False(t, iso.HasElTorito())
+	require.Zero(t, iso.RootDirectoryLocation())
+
+	entries, err := iso.ListBootEntries()
+	require.NoError(t, err)
+	require.Nil(t, entries)
+
+	require.NotNil(t, iso.GetLogger())
+	require.NoError(t, iso.Close())
+}
+
+func TestGettersPreferJoliet(t *testing.T) {
+	iso, err := Create("PRIMARYID", option.WithJolietEnabled(true))
+	require.NoError(t, err)
+	require.NoError(t, iso.AddFile("a.txt", []byte("x")))
+	path := saveToTempFile(t, iso)
+
+	f, err := os.Open(path)
+	require.NoError(t, err)
+	defer f.Close()
+
+	viaJoliet, err := Open(f, option.WithPreferJoliet(true))
+	require.NoError(t, err)
+	require.Equal(t, "PRIMARYID", viaJoliet.GetVolumeID())
+	require.NotZero(t, viaJoliet.RootDirectoryLocation())
+	require.False(t, viaJoliet.GetCreationDateTime().IsZero())
+}
+
+func TestGetLayoutAndObjects(t *testing.T) {
+	iso, err := Create("LAYOUT")
+	require.NoError(t, err)
+	require.NoError(t, iso.AddFile("f.txt", []byte("data")))
+	path := saveToTempFile(t, iso)
+
+	f, err := os.Open(path)
+	require.NoError(t, err)
+	defer f.Close()
+
+	reopened, err := Open(f)
+	require.NoError(t, err)
+
+	layout := reopened.GetLayout()
+	require.NotNil(t, layout)
+	require.NotEmpty(t, layout.Objects)
+
+	// Layout objects include the system area and the PVD.
+	var names []string
+	for _, obj := range layout.Objects {
+		names = append(names, obj.Name())
+	}
+	require.Contains(t, names, "System Area")
+}
+
+func TestPristinePassthroughSave(t *testing.T) {
+	iso, err := Create("PRISTINE2")
+	require.NoError(t, err)
+	require.NoError(t, iso.AddFile("keep.txt", []byte("original")))
+	basePath := saveToTempFile(t, iso)
+
+	base, err := os.Open(basePath)
+	require.NoError(t, err)
+	defer base.Close()
+
+	opened, err := Open(base)
+	require.NoError(t, err)
+	require.False(t, opened.isDirty, "opened image starts clean")
+
+	// An untouched image takes the passthrough path (no repack).
+	resavePath := saveToTempFile(t, opened)
+	require.False(t, opened.isDirty)
+
+	re, err := os.Open(resavePath)
+	require.NoError(t, err)
+	defer re.Close()
+	reopened, err := Open(re)
+	require.NoError(t, err)
+	data, err := reopened.ReadFile("keep.txt")
+	require.NoError(t, err)
+	require.Equal(t, []byte("original"), data)
+}
+
+func TestReadFileErrors(t *testing.T) {
+	iso, err := Create("ERRS")
+	require.NoError(t, err)
+	require.NoError(t, iso.AddDirectory("adir"))
+
+	_, err = iso.ReadFile("missing.txt")
+	require.Error(t, err)
+
+	_, err = iso.ReadFile("adir")
+	require.Error(t, err, "reading a directory should fail")
+
+	require.Error(t, iso.RemoveFile("missing.txt"))
+	require.Error(t, iso.RemoveFile("adir"), "RemoveFile on a directory should fail")
+	require.Error(t, iso.RemoveDirectory("missing"))
+	require.NoError(t, iso.AddFile("afile", []byte("x")))
+	require.Error(t, iso.RemoveDirectory("afile"), "RemoveDirectory on a file should fail")
+	require.NoError(t, iso.RemoveDirectory("adir"))
+}
+
+func TestExtractCreatedImage(t *testing.T) {
+	// Extract must work on a created-then-reopened image and preserve
+	// mode bits through Rock Ridge.
+	iso, err := Create("EXTRACT2")
+	require.NoError(t, err)
+	require.NoError(t, iso.AddFile("bin/tool.sh", []byte("#!/bin/sh\nexit 0\n")))
+	node := isoLookup(t, iso, "bin/tool.sh")
+	node.SetMode(0o755)
+	path := saveToTempFile(t, iso)
+
+	f, err := os.Open(path)
+	require.NoError(t, err)
+	defer f.Close()
+	reopened, err := Open(f)
+	require.NoError(t, err)
+
+	outDir := t.TempDir()
+	require.NoError(t, reopened.Extract(outDir))
+
+	fi, err := os.Stat(outDir + "/bin/tool.sh")
+	require.NoError(t, err)
+	require.Equal(t, os.FileMode(0o755), fi.Mode().Perm())
+}
+
+func TestAddLocalDirectory(t *testing.T) {
+	srcDir := t.TempDir()
+	require.NoError(t, os.MkdirAll(srcDir+"/nested", 0o755))
+	require.NoError(t, os.WriteFile(srcDir+"/top.txt", []byte("top"), 0o600))
+	require.NoError(t, os.WriteFile(srcDir+"/nested/deep.txt", []byte("deep"), 0o644))
+	require.NoError(t, os.Symlink("top.txt", srcDir+"/link"))
+
+	iso, err := Create("LOCALDIR")
+	require.NoError(t, err)
+	require.NoError(t, iso.AddLocalDirectory(srcDir, "/imported"))
+
+	data, err := iso.ReadFile("imported/top.txt")
+	require.NoError(t, err)
+	require.Equal(t, []byte("top"), data)
+
+	data, err = iso.ReadFile("imported/nested/deep.txt")
+	require.NoError(t, err)
+	require.Equal(t, []byte("deep"), data)
+
+	link := iso.root.Lookup("imported/link")
+	require.NotNil(t, link)
+	require.True(t, link.IsSymlink())
+	require.Equal(t, "top.txt", link.SymlinkTarget())
+
+	// Imported permissions survive.
+	top := isoLookup(t, iso, "imported/top.txt")
+	require.Equal(t, os.FileMode(0o600), top.Mode().Perm())
+}

--- a/pkg/iso9660/boot/eltorito.go
+++ b/pkg/iso9660/boot/eltorito.go
@@ -332,6 +332,20 @@ func (et *ElTorito) UnmarshalBinary(data []byte) error {
 	for offset := 32; offset < len(data); offset += 32 {
 		entryData := data[offset : offset+32]
 
+		// Entries promised by a section header are consumed even with a
+		// 0x00 boot indicator: not-bootable entries share that value
+		// with empty catalog space, and only the header count
+		// disambiguates them.
+		if sectionCount > 0 {
+			entry := parseCatalogEntry(entryData, currentPlatform)
+			if et.Logger != nil {
+				et.Logger.Trace("Parsed section entry", "entry", entry)
+			}
+			et.Entries = append(et.Entries, entry)
+			sectionCount--
+			continue
+		}
+
 		// Check for End of Catalog
 		if entryData[0] == 0x00 {
 			if et.Logger != nil {
@@ -347,17 +361,6 @@ func (et *ElTorito) UnmarshalBinary(data []byte) error {
 			if et.Logger != nil {
 				et.Logger.Debug("Section header found", "offset", offset, "entries", sectionCount)
 			}
-			continue
-		}
-
-		// Parse Section Entries
-		if sectionCount > 0 {
-			entry := parseCatalogEntry(entryData, currentPlatform)
-			if et.Logger != nil {
-				et.Logger.Trace("Parsed section entry", "entry", entry)
-			}
-			et.Entries = append(et.Entries, entry)
-			sectionCount--
 			continue
 		}
 

--- a/pkg/iso9660/boot/eltorito_test.go
+++ b/pkg/iso9660/boot/eltorito_test.go
@@ -1,0 +1,177 @@
+package boot
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCatalogRoundTripSingleEntry(t *testing.T) {
+	et := &ElTorito{
+		Entries: []*ElToritoEntry{{
+			Platform:    BIOS,
+			Emulation:   NoEmulation,
+			Bootable:    true,
+			LoadSegment: 0x7C0,
+		}},
+	}
+	et.Entries[0].SetExtent(500, 24*1024)
+
+	data, err := et.Marshal()
+	require.NoError(t, err)
+	require.Len(t, data, 2048)
+
+	decoded := &ElTorito{}
+	require.NoError(t, decoded.UnmarshalBinary(data))
+	require.Equal(t, BIOS, decoded.Platform)
+	require.Len(t, decoded.Entries, 1)
+
+	e := decoded.Entries[0]
+	require.True(t, e.Bootable)
+	require.Equal(t, BIOS, e.Platform)
+	require.Equal(t, NoEmulation, e.Emulation)
+	require.Equal(t, uint16(0x7C0), e.LoadSegment)
+	require.Equal(t, uint32(500), e.Location())
+	require.Equal(t, uint16(48), e.SectorCount()) // 24 KiB / 512
+}
+
+func TestCatalogRoundTripMultiPlatformSections(t *testing.T) {
+	et := &ElTorito{
+		Entries: []*ElToritoEntry{
+			{Platform: BIOS, Emulation: NoEmulation, Bootable: true},
+			{Platform: EFI, Emulation: NoEmulation, Bootable: true},
+			{Platform: EFI, Emulation: NoEmulation, Bootable: false},
+		},
+	}
+	et.Entries[0].SetExtent(100, 2048)
+	et.Entries[1].SetExtent(200, 1440*1024)
+	et.Entries[2].SetExtent(300, 4096)
+
+	data, err := et.Marshal()
+	require.NoError(t, err)
+
+	// Section header for the EFI group: 0x91 (final), platform EFI,
+	// two entries.
+	require.Equal(t, byte(0x91), data[64])
+	require.Equal(t, byte(EFI), data[65])
+	require.Equal(t, byte(2), data[66])
+
+	decoded := &ElTorito{}
+	require.NoError(t, decoded.UnmarshalBinary(data))
+	require.Len(t, decoded.Entries, 3)
+	require.Equal(t, BIOS, decoded.Entries[0].Platform)
+	require.Equal(t, EFI, decoded.Entries[1].Platform)
+	require.Equal(t, EFI, decoded.Entries[2].Platform)
+	require.True(t, decoded.Entries[1].Bootable)
+	require.False(t, decoded.Entries[2].Bootable)
+	require.Equal(t, uint32(200), decoded.Entries[1].Location())
+}
+
+func TestValidationEntryChecksum(t *testing.T) {
+	et := &ElTorito{Entries: []*ElToritoEntry{{Platform: BIOS, Bootable: true}}}
+	et.Entries[0].SetExtent(1, 512)
+	data, err := et.Marshal()
+	require.NoError(t, err)
+
+	// A corrupted validation entry must be rejected.
+	corrupt := bytes.Clone(data)
+	corrupt[10] ^= 0xFF
+	require.Error(t, (&ElTorito{}).UnmarshalBinary(corrupt))
+
+	// Missing 0x55AA key bytes must be rejected.
+	noKey := bytes.Clone(data)
+	noKey[0x1E] = 0
+	require.Error(t, (&ElTorito{}).UnmarshalBinary(noKey))
+
+	// Truncated catalogs must be rejected.
+	require.Error(t, (&ElTorito{}).UnmarshalBinary(data[:16]))
+}
+
+func TestMarshalEmptyCatalog(t *testing.T) {
+	_, err := (&ElTorito{}).Marshal()
+	require.Error(t, err)
+}
+
+func TestSetExtentLoadSizeSemantics(t *testing.T) {
+	// Explicit LoadSize wins.
+	e := &ElToritoEntry{LoadSize: 4}
+	e.SetExtent(10, 1<<20)
+	require.Equal(t, uint16(4), e.SectorCount())
+
+	// Auto: rounded-up 512-byte blocks.
+	e = &ElToritoEntry{}
+	e.SetExtent(10, 1000)
+	require.Equal(t, uint16(2), e.SectorCount())
+
+	// Zero-size images still load one sector.
+	e = &ElToritoEntry{}
+	e.SetExtent(10, 0)
+	require.Equal(t, uint16(1), e.SectorCount())
+
+	// Saturates at the 16-bit ceiling.
+	e = &ElToritoEntry{}
+	e.SetExtent(10, 64*1024*1024)
+	require.Equal(t, uint16(0xFFFF), e.SectorCount())
+}
+
+func TestBuildBootImageEntriesSizes(t *testing.T) {
+	et := &ElTorito{
+		Entries: []*ElToritoEntry{
+			{Platform: BIOS, Bootable: true},
+			{Platform: BIOS}, // location 0: skipped
+		},
+	}
+	// A >128 KiB image: the size math must not truncate at 16 bits.
+	et.Entries[0].SetExtent(700, 1440*1024)
+
+	entries, err := et.BuildBootImageEntries()
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	require.Equal(t, uint64(1440*1024), entries[0].Size)
+	require.Equal(t, uint32(700), entries[0].Location)
+}
+
+func TestExtractBootImages(t *testing.T) {
+	// Backing image: boot content at sector 10.
+	backing := make([]byte, 20*2048)
+	payload := []byte("BOOTPAYLOAD")
+	copy(backing[10*2048:], payload)
+
+	et := &ElTorito{Entries: []*ElToritoEntry{{Platform: BIOS, Emulation: NoEmulation, Bootable: true}}}
+	et.Entries[0].SetExtent(10, 512)
+
+	outDir := t.TempDir()
+	require.NoError(t, et.ExtractBootImages(bytes.NewReader(backing), outDir))
+
+	files, err := os.ReadDir(outDir)
+	require.NoError(t, err)
+	require.Len(t, files, 1)
+
+	data, err := os.ReadFile(filepath.Join(outDir, files[0].Name()))
+	require.NoError(t, err)
+	require.Len(t, data, 512)
+	require.Equal(t, payload, data[:len(payload)])
+}
+
+func TestIsElTorito(t *testing.T) {
+	require.True(t, IsElTorito("EL TORITO SPECIFICATION"))
+	require.True(t, IsElTorito("EL TORITO SPECIFICATION\x00\x00"))
+	require.False(t, IsElTorito("NOT A BOOT SYSTEM"))
+	require.False(t, IsElTorito(""))
+}
+
+func TestEnumStrings(t *testing.T) {
+	require.Equal(t, "BIOS", BIOS.String())
+	require.Equal(t, "EFI", EFI.String())
+	require.Equal(t, "Unknown", Platform(0x42).String())
+
+	require.Equal(t, "NoEmul", NoEmulation.String())
+	require.Equal(t, "HardDisk", HardDiskEmulation.String())
+	require.Equal(t, "Unknown", Emulation(0x42).String())
+
+	require.Equal(t, "EFI System", EFISystem.String())
+	require.Equal(t, "Unknown", PartitionType(0x42).String())
+}

--- a/pkg/iso9660/directory/record_test.go
+++ b/pkg/iso9660/directory/record_test.go
@@ -1,0 +1,141 @@
+package directory
+
+import (
+	"testing"
+	"time"
+
+	"github.com/bgrewell/iso-kit/pkg/iso9660/encoding"
+	"github.com/bgrewell/iso-kit/pkg/iso9660/extensions"
+	"github.com/stretchr/testify/require"
+)
+
+func makeRecord(identifier string) *DirectoryRecord {
+	return &DirectoryRecord{
+		LocationOfExtent:       1234,
+		DataLength:             5678,
+		RecordingDateAndTime:   time.Date(2022, 5, 6, 7, 8, 9, 0, time.UTC),
+		FileFlags:              FileFlags{},
+		VolumeSequenceNumber:   1,
+		LengthOfFileIdentifier: uint8(len(identifier)),
+		FileIdentifier:         identifier,
+	}
+}
+
+func TestRecordRoundTrip(t *testing.T) {
+	original := makeRecord("HELLO.TXT;1")
+	original.SystemUse = []byte{'R', 'R', 5, 1, 0x81, 0}
+
+	data, err := original.Marshal()
+	require.NoError(t, err)
+	require.Equal(t, int(data[0]), len(data), "length byte must equal record size")
+	require.Zero(t, len(data)%2, "records must have even length")
+
+	var decoded DirectoryRecord
+	require.NoError(t, decoded.Unmarshal(data))
+	require.Equal(t, uint32(1234), decoded.LocationOfExtent)
+	require.Equal(t, uint32(5678), decoded.DataLength)
+	require.Equal(t, "HELLO.TXT;1", decoded.FileIdentifier)
+	require.Equal(t, original.SystemUse, decoded.SystemUse)
+	require.True(t, decoded.RecordingDateAndTime.Equal(original.RecordingDateAndTime))
+}
+
+func TestRecordFlagsRoundTrip(t *testing.T) {
+	original := makeRecord("DIR")
+	original.FileFlags = FileFlags{Directory: true, Hidden: true, MultiExtent: true}
+
+	data, err := original.Marshal()
+	require.NoError(t, err)
+
+	var decoded DirectoryRecord
+	require.NoError(t, decoded.Unmarshal(data))
+	require.True(t, decoded.FileFlags.Directory)
+	require.True(t, decoded.FileFlags.Hidden)
+	require.True(t, decoded.FileFlags.MultiExtent)
+	require.False(t, decoded.FileFlags.AssociatedFile)
+}
+
+func TestRecordPaddingByte(t *testing.T) {
+	// Even-length identifiers get a pad byte; odd-length ones do not.
+	even, err := makeRecord("AB").Marshal()
+	require.NoError(t, err)
+	odd, err := makeRecord("ABC").Marshal()
+	require.NoError(t, err)
+	require.Equal(t, len(even), len(odd), "pad byte should equalize record sizes")
+
+	var decoded DirectoryRecord
+	require.NoError(t, decoded.Unmarshal(even))
+	require.Equal(t, "AB", decoded.FileIdentifier)
+}
+
+func TestRecordJolietIdentifierDecoding(t *testing.T) {
+	name := "Ünïcode Nämé"
+	encoded := string(encoding.EncodeUCS2BigEndian(name))
+	original := makeRecord(encoded)
+
+	data, err := original.Marshal()
+	require.NoError(t, err)
+
+	decoded := DirectoryRecord{Joliet: true}
+	require.NoError(t, decoded.Unmarshal(data))
+	require.Equal(t, name, decoded.FileIdentifier)
+
+	// Special identifiers stay single-byte even under Joliet.
+	special := makeRecord("\x00")
+	data, err = special.Marshal()
+	require.NoError(t, err)
+	decoded = DirectoryRecord{Joliet: true}
+	require.NoError(t, decoded.Unmarshal(data))
+	require.Equal(t, "\x00", decoded.FileIdentifier)
+}
+
+func TestRecordUnmarshalErrors(t *testing.T) {
+	var decoded DirectoryRecord
+	require.Error(t, decoded.Unmarshal(nil))
+
+	// Claimed length larger than the provided data.
+	require.Error(t, decoded.Unmarshal([]byte{200, 0, 0}))
+}
+
+func TestIsSpecialAndBestName(t *testing.T) {
+	dot := makeRecord("\x00")
+	require.True(t, dot.IsSpecial())
+	require.Equal(t, ".", dot.GetBestName(false))
+
+	dotdot := makeRecord("\x01")
+	require.True(t, dotdot.IsSpecial())
+	require.Equal(t, "..", dotdot.GetBestName(false))
+
+	plain := makeRecord("FILE.TXT;1")
+	require.False(t, plain.IsSpecial())
+	require.Equal(t, "FILE.TXT;1", plain.GetBestName(false))
+
+	// Rock Ridge alternate name wins when enabled.
+	altName := "real-name.txt"
+	plain.RockRidge = &extensions.RockRidgeExtensions{AlternateName: &altName}
+	require.Equal(t, altName, plain.GetBestName(true))
+	require.Equal(t, "FILE.TXT;1", plain.GetBestName(false))
+}
+
+func TestGetPermissionsDefaults(t *testing.T) {
+	file := makeRecord("F;1")
+	require.Equal(t, uint32(0o644), uint32(file.GetPermissions(false).Perm()))
+
+	dir := makeRecord("D")
+	dir.FileFlags.Directory = true
+	require.Equal(t, uint32(0o755), uint32(dir.GetPermissions(false).Perm()))
+}
+
+func TestFileFlagsMarshalBits(t *testing.T) {
+	all := FileFlags{Hidden: true, Directory: true, AssociatedFile: true, RecordFormat: true, Protection: true, MultiExtent: true}
+	b := all.Marshal()
+	require.Equal(t, byte(0x9F), b)
+
+	decoded, err := UnmarshalFileFlags(b)
+	require.NoError(t, err)
+	require.Equal(t, all, decoded)
+
+	// Reserved bits are tolerated on read.
+	withReserved, err := UnmarshalFileFlags(0x60)
+	require.NoError(t, err)
+	require.Equal(t, FileFlags{}, withReserved)
+}

--- a/pkg/iso9660/encoding/encoding_edge_test.go
+++ b/pkg/iso9660/encoding/encoding_edge_test.go
@@ -1,0 +1,89 @@
+package encoding
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBothByteOrders32(t *testing.T) {
+	data := MarshalBothByteOrders32(0x12345678)
+	require.Equal(t, [8]byte{0x78, 0x56, 0x34, 0x12, 0x12, 0x34, 0x56, 0x78}, data)
+
+	value, err := UnmarshalUint32LSBMSB(data)
+	require.NoError(t, err)
+	require.Equal(t, uint32(0x12345678), value)
+
+	// Mismatched halves are corrupt data.
+	data[0] = 0xFF
+	_, err = UnmarshalUint32LSBMSB(data)
+	require.Error(t, err)
+}
+
+func TestBothByteOrders16(t *testing.T) {
+	data := MarshalBothByteOrders16(0x1234)
+	require.Equal(t, [4]byte{0x34, 0x12, 0x12, 0x34}, data)
+
+	value, err := UnmarshalUint16LSBMSB(data)
+	require.NoError(t, err)
+	require.Equal(t, uint16(0x1234), value)
+
+	data[3] = 0xFF
+	_, err = UnmarshalUint16LSBMSB(data)
+	require.Error(t, err)
+}
+
+func TestRecordingDateTimeRoundTrip(t *testing.T) {
+	for _, tc := range []time.Time{
+		time.Date(1900, 1, 1, 0, 0, 0, 0, time.UTC),
+		time.Date(2155, 12, 31, 23, 59, 59, 0, time.UTC),
+		time.Date(2024, 6, 15, 12, 30, 45, 0, time.FixedZone("UTC+2", 2*3600)),
+	} {
+		data, err := MarshalRecordingDateTime(tc)
+		require.NoError(t, err)
+		back, err := UnmarshalRecordingDateTime(data)
+		require.NoError(t, err)
+		require.True(t, back.Equal(tc), "round trip mismatch: got %v want %v", back, tc)
+	}
+}
+
+func TestRecordingDateTimeYearBounds(t *testing.T) {
+	_, err := MarshalRecordingDateTime(time.Date(1899, 12, 31, 0, 0, 0, 0, time.UTC))
+	require.Error(t, err)
+	_, err = MarshalRecordingDateTime(time.Date(2156, 1, 1, 0, 0, 0, 0, time.UTC))
+	require.Error(t, err)
+}
+
+func TestDateTimeOffsetRoundTrip(t *testing.T) {
+	// Positive and negative timezone offsets survive the 17-byte format.
+	for _, tc := range []time.Time{
+		time.Date(2020, 2, 29, 6, 7, 8, 0, time.FixedZone("UTC-6", -6*3600)),
+		time.Date(2020, 2, 29, 6, 7, 8, 0, time.FixedZone("UTC+5:30", 5*3600+1800)),
+	} {
+		data, err := MarshalDateTime(tc)
+		require.NoError(t, err)
+		back, err := UnmarshalDateTime(data)
+		require.NoError(t, err)
+		require.True(t, back.Equal(tc), "round trip mismatch: got %v want %v", back, tc)
+	}
+}
+
+func TestUCS2EncodeDecodeRoundTrip(t *testing.T) {
+	for _, s := range []string{
+		"",
+		"ASCII",
+		"Ünïcödé",
+		"日本語",
+	} {
+		encoded := EncodeUCS2BigEndian(s)
+		require.Zero(t, len(encoded)%2)
+		require.Equal(t, s, DecodeUCS2BigEndian(encoded), "round trip for %q", s)
+	}
+}
+
+func TestDecodeUCS2OddLength(t *testing.T) {
+	// Trailing odd byte is ignored rather than corrupting the result.
+	encoded := EncodeUCS2BigEndian("AB")
+	require.Equal(t, "AB", DecodeUCS2BigEndian(append(encoded, 0x00)))
+}

--- a/pkg/iso9660/extensions/rockridge_test.go
+++ b/pkg/iso9660/extensions/rockridge_test.go
@@ -1,0 +1,190 @@
+package extensions
+
+import (
+	"io/fs"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func ptr[T any](v T) *T { return &v }
+
+func TestRockRidgeMarshalUnmarshalRoundTrip(t *testing.T) {
+	perms := fs.FileMode(0o754)
+	modTime := time.Date(2021, 3, 14, 15, 9, 26, 0, time.UTC)
+	rr := &RockRidgeExtensions{
+		UID:              ptr(uint32(1000)),
+		GID:              ptr(uint32(2000)),
+		Permissions:      &perms,
+		Major:            ptr(uint32(8)),
+		Minor:            ptr(uint32(1)),
+		SymlinkTarget:    ptr("../lib/target"),
+		AlternateName:    ptr("Long Mixed Case Name.txt"),
+		ChildLinkLBA:     ptr(uint32(1234)),
+		ParentLinkLBA:    ptr(uint32(5678)),
+		IsRelocated:      ptr(true),
+		ModificationTime: &modTime,
+	}
+
+	data, err := MarshalRockRidge(rr)
+	require.NoError(t, err)
+
+	decoded, err := UnmarshalRockRidge(data)
+	require.NoError(t, err)
+
+	require.Equal(t, uint32(1000), *decoded.UID)
+	require.Equal(t, uint32(2000), *decoded.GID)
+	require.Equal(t, perms.Perm(), decoded.Permissions.Perm())
+	require.Equal(t, uint32(8), *decoded.Major)
+	require.Equal(t, uint32(1), *decoded.Minor)
+	require.Equal(t, "../lib/target", *decoded.SymlinkTarget)
+	require.Equal(t, "Long Mixed Case Name.txt", *decoded.AlternateName)
+	require.Equal(t, uint32(1234), *decoded.ChildLinkLBA)
+	require.Equal(t, uint32(5678), *decoded.ParentLinkLBA)
+	require.True(t, *decoded.IsRelocated)
+	require.True(t, decoded.ModificationTime.Equal(modTime), "mod time: got %v", decoded.ModificationTime)
+}
+
+func TestSymlinkTargetRoundTrips(t *testing.T) {
+	for _, target := range []string{
+		"simple",
+		"dir/nested/leaf",
+		"/absolute/path",
+		"../parent/relative",
+		"./current/style",
+		"/",
+		"../../up/twice",
+	} {
+		rr := &RockRidgeExtensions{SymlinkTarget: &target}
+		data, err := MarshalRockRidge(rr)
+		require.NoError(t, err)
+		decoded, err := UnmarshalRockRidge(data)
+		require.NoError(t, err)
+		require.NotNil(t, decoded.SymlinkTarget, "target %q lost", target)
+		require.Equal(t, target, *decoded.SymlinkTarget)
+	}
+}
+
+func TestLongNameSplitsAcrossNMEntries(t *testing.T) {
+	// Longer than one NM entry's payload capacity: must split with the
+	// continue flag and reassemble on parse.
+	longName := strings.Repeat("abcdefghij", 30) // 300 bytes
+	nm := BuildNM(longName)
+	require.Greater(t, len(nm), 1, "expected multiple NM entries")
+	require.NotZero(t, nm[0][4]&NM_CONTINUE, "first entry should carry the continue flag")
+	require.Zero(t, nm[len(nm)-1][4]&NM_CONTINUE, "final entry should not continue")
+
+	var data []byte
+	for _, e := range nm {
+		data = append(data, e...)
+	}
+	decoded, err := UnmarshalRockRidge(data)
+	require.NoError(t, err)
+	require.Equal(t, longName, *decoded.AlternateName)
+}
+
+func TestTFLongFormParsing(t *testing.T) {
+	// Long-form TF uses 17-byte timestamps (flag bit 7).
+	modTime := time.Date(2019, 7, 20, 20, 17, 40, 0, time.UTC)
+	stamp := [17]byte{}
+	copy(stamp[:], "2019072020174000")
+	// Digits: YYYYMMDDhhmmsscc then offset 0.
+	copy(stamp[:], []byte("2019072020174000"))
+	stamp[16] = 0
+
+	entry := []byte{'T', 'F', byte(4 + 1 + 17), 1, TF_MODIFY | TF_LONG_FORM}
+	entry = append(entry, stamp[:]...)
+
+	decoded, err := UnmarshalRockRidge(entry)
+	require.NoError(t, err)
+	require.NotNil(t, decoded.ModificationTime)
+	require.True(t, decoded.ModificationTime.Equal(modTime), "got %v want %v", decoded.ModificationTime, modTime)
+}
+
+func TestPosixModeParseFileModeInverse(t *testing.T) {
+	cases := []fs.FileMode{
+		0o644,
+		0o755,
+		0o400,
+		fs.ModeDir | 0o755,
+		fs.ModeSymlink | 0o777,
+		fs.ModeSetuid | 0o755,
+		fs.ModeSetgid | 0o750,
+		fs.ModeSticky | 0o777,
+	}
+	for _, mode := range cases {
+		bits := PosixMode(mode)
+		back := parseFileMode(bits)
+		require.Equal(t, mode.Perm(), back.Perm(), "perm mismatch for %v", mode)
+		require.Equal(t, mode&fs.ModeDir, back&fs.ModeDir, "dir bit for %v", mode)
+		require.Equal(t, mode&fs.ModeSymlink, back&fs.ModeSymlink, "symlink bit for %v", mode)
+		require.Equal(t, mode&fs.ModeSetuid, back&fs.ModeSetuid, "setuid for %v", mode)
+		require.Equal(t, mode&fs.ModeSetgid, back&fs.ModeSetgid, "setgid for %v", mode)
+		require.Equal(t, mode&fs.ModeSticky, back&fs.ModeSticky, "sticky for %v", mode)
+	}
+}
+
+func TestSUSPEntryShapes(t *testing.T) {
+	sp := BuildSP(0)
+	require.Len(t, sp, 7)
+	require.Equal(t, "SP", string(sp[:2]))
+	require.Equal(t, byte(0xBE), sp[4])
+	require.Equal(t, byte(0xEF), sp[5])
+
+	ce := BuildCE(100, 256, 237)
+	require.Len(t, ce, 28)
+	require.Equal(t, "CE", string(ce[:2]))
+	require.Equal(t, byte(28), ce[2])
+
+	er := BuildER()
+	require.Equal(t, "ER", string(er[:2]))
+	require.Equal(t, len(er), int(er[2]))
+	require.Contains(t, string(er), RRIP_ER_ID)
+
+	st := BuildST()
+	require.Equal(t, []byte{'S', 'T', 4, 1}, st)
+
+	rr := BuildRR(0x89)
+	require.Equal(t, []byte{'R', 'R', 5, 1, 0x89}, rr)
+
+	px := BuildPX(0o644, 1, 0, 0)
+	require.Len(t, px, 36)
+	require.Equal(t, int(px[2]), len(px))
+}
+
+func TestUnmarshalIgnoresUnknownAndStopsAtST(t *testing.T) {
+	name := "x"
+	nm := BuildNM(name)[0]
+
+	// Unknown entry, then NM, then ST, then garbage that must not be read.
+	data := []byte{'Z', 'Z', 6, 1, 0, 0}
+	data = append(data, nm...)
+	data = append(data, BuildST()...)
+	data = append(data, 'N', 'M', 200, 1) // truncated garbage after ST
+
+	decoded, err := UnmarshalRockRidge(data)
+	require.NoError(t, err)
+	require.Equal(t, name, *decoded.AlternateName)
+}
+
+func TestUnmarshalTooShort(t *testing.T) {
+	_, err := UnmarshalRockRidge([]byte{1, 2})
+	require.Error(t, err)
+}
+
+func TestCEParsing(t *testing.T) {
+	decoded, err := UnmarshalRockRidge(BuildCE(50, 512, 300))
+	require.NoError(t, err)
+	require.NotNil(t, decoded.Continuation)
+	require.Equal(t, uint32(50), decoded.Continuation.Block)
+	require.Equal(t, uint32(512), decoded.Continuation.Offset)
+	require.Equal(t, uint32(300), decoded.Continuation.Length)
+}
+
+func TestHasRockRidge(t *testing.T) {
+	require.False(t, (&RockRidgeExtensions{}).HasRockRidge())
+	require.True(t, (&RockRidgeExtensions{UID: ptr(uint32(0))}).HasRockRidge())
+	require.True(t, (&RockRidgeExtensions{SymlinkTarget: ptr("x")}).HasRockRidge())
+}

--- a/pkg/iso9660/pathtable/record_test.go
+++ b/pkg/iso9660/pathtable/record_test.go
@@ -1,0 +1,98 @@
+package pathtable
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPathTableRecordRoundTrip(t *testing.T) {
+	for _, littleEndian := range []bool{true, false} {
+		for _, id := range []string{"A", "AB", "SUBDIR", "\x00"} {
+			original := &PathTableRecord{
+				LocationOfExtent:      4321,
+				ParentDirectoryNumber: 7,
+				DirectoryIdentifier:   id,
+				littleEndian:          littleEndian,
+			}
+
+			data, err := original.Marshal()
+			require.NoError(t, err)
+
+			// Records with odd identifier lengths carry a pad byte.
+			wantLen := 8 + len(id)
+			if len(id)%2 != 0 {
+				wantLen++
+			}
+			require.Len(t, data, wantLen)
+
+			var decoded PathTableRecord
+			require.NoError(t, decoded.Unmarshal(data, littleEndian))
+			require.Equal(t, uint32(4321), decoded.LocationOfExtent, "endian=%v id=%q", littleEndian, id)
+			require.Equal(t, uint16(7), decoded.ParentDirectoryNumber)
+			require.Equal(t, id, decoded.DirectoryIdentifier)
+		}
+	}
+}
+
+func TestPathTableEndianDiffers(t *testing.T) {
+	le := &PathTableRecord{LocationOfExtent: 0x01020304, ParentDirectoryNumber: 0x0506, DirectoryIdentifier: "X", littleEndian: true}
+	be := &PathTableRecord{LocationOfExtent: 0x01020304, ParentDirectoryNumber: 0x0506, DirectoryIdentifier: "X", littleEndian: false}
+
+	leData, err := le.Marshal()
+	require.NoError(t, err)
+	beData, err := be.Marshal()
+	require.NoError(t, err)
+	require.False(t, bytes.Equal(leData, beData), "L and M tables must differ in byte order")
+
+	// Cross-decoding with the right endianness recovers the values.
+	var decoded PathTableRecord
+	require.NoError(t, decoded.Unmarshal(beData, false))
+	require.Equal(t, uint32(0x01020304), decoded.LocationOfExtent)
+}
+
+func TestBuildPathTableFromRecords(t *testing.T) {
+	pt := NewEmptyPathTable("Primary", true)
+	pt.AddRecord("\x00", 20, 1)
+	pt.AddRecord("BIN", 21, 1)
+	pt.AddRecord("DOCS", 22, 1)
+	pt.AddRecord("DEEP", 23, 3)
+	pt.SetLocation(18, 40)
+
+	data, err := pt.Marshal()
+	require.NoError(t, err)
+
+	// Reparse the marshaled table record-by-record.
+	var records []*PathTableRecord
+	offset := 0
+	for offset < len(data) {
+		var rec PathTableRecord
+		require.NoError(t, rec.Unmarshal(data[offset:], true))
+		records = append(records, &rec)
+		recLen := 8 + int(rec.LengthOfDirectoryIdentifier)
+		if rec.LengthOfDirectoryIdentifier%2 != 0 {
+			recLen++
+		}
+		offset += recLen
+	}
+
+	require.Len(t, records, 4)
+	require.Equal(t, "\x00", records[0].DirectoryIdentifier)
+	require.Equal(t, uint16(1), records[1].ParentDirectoryNumber)
+	require.Equal(t, "DEEP", records[3].DirectoryIdentifier)
+	require.Equal(t, uint16(3), records[3].ParentDirectoryNumber)
+	require.Equal(t, uint32(23), records[3].LocationOfExtent)
+
+	require.Equal(t, int64(18*2048), pt.Offset())
+	require.Equal(t, 40, pt.Size())
+}
+
+func TestPathTableRecordUnmarshalErrors(t *testing.T) {
+	var rec PathTableRecord
+	require.Error(t, rec.Unmarshal([]byte{1, 2, 3}, true))
+
+	// Identifier length exceeding the data.
+	bad := []byte{10, 0, 0, 0, 0, 0, 0, 0, 'A'}
+	require.Error(t, rec.Unmarshal(bad, true))
+}

--- a/pkg/iso9660/systemarea/systemarea_test.go
+++ b/pkg/iso9660/systemarea/systemarea_test.go
@@ -1,0 +1,118 @@
+package systemarea
+
+import (
+	"encoding/binary"
+	"hash/crc32"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMBRRoundTrip(t *testing.T) {
+	original := &MBR{DiskSignature: 0xDEADBEEF}
+	copy(original.BootCode[:], "BOOTCODE")
+	original.Partitions[0] = MBRPartition{Status: 0x80, Type: MBR_TYPE_ISO9660, StartLBA: 0, SizeLBA: 4096}
+	original.Partitions[1] = MBRPartition{Type: MBR_TYPE_EFI_SYSTEM, StartLBA: 128, SizeLBA: 2880}
+
+	data := original.Marshal()
+	require.Len(t, data, 512)
+	require.True(t, HasBootSignature(data))
+
+	decoded := ParseMBR(data)
+	require.NotNil(t, decoded)
+	require.Equal(t, uint32(0xDEADBEEF), decoded.DiskSignature)
+	require.Equal(t, []byte("BOOTCODE"), decoded.BootCode[:8])
+	require.Equal(t, original.Partitions[0], decoded.Partitions[0])
+	require.Equal(t, original.Partitions[1], decoded.Partitions[1])
+	require.True(t, decoded.Partitions[2].IsEmpty())
+}
+
+func TestParseMBRRejectsMissingSignature(t *testing.T) {
+	require.Nil(t, ParseMBR(make([]byte, 512)))
+	require.Nil(t, ParseMBR([]byte{1, 2, 3}))
+	require.False(t, HasBootSignature(make([]byte, 100)))
+}
+
+func TestCHSSaturation(t *testing.T) {
+	// Small LBA: a real CHS tuple.
+	small := chsFor(0)
+	require.Equal(t, [3]byte{0, 1, 0}, small)
+
+	// Beyond the 1023-cylinder limit: the conventional saturation value.
+	require.Equal(t, chsBeyond, chsFor(1024*64*32))
+}
+
+func TestSetPartitionBounds(t *testing.T) {
+	m := &MBR{}
+	require.NoError(t, m.SetPartition(0, MBRPartition{Type: 1, SizeLBA: 1}))
+	require.NoError(t, m.SetPartition(3, MBRPartition{Type: 1, SizeLBA: 1}))
+	require.Error(t, m.SetPartition(4, MBRPartition{}))
+	require.Error(t, m.SetPartition(-1, MBRPartition{}))
+}
+
+func TestGPTBuildInvariants(t *testing.T) {
+	g := &GPT{
+		Partitions: []GPTPartition{{
+			TypeGUID: GUID_EFI_SYSTEM,
+			FirstLBA: 100,
+			LastLBA:  199,
+			Name:     "EFI System Partition",
+		}},
+	}
+	const totalLBAs = 10000
+	layout, err := g.Build(totalLBAs)
+	require.NoError(t, err)
+
+	// Header basics.
+	h := layout.PrimaryHeader
+	require.Equal(t, []byte("EFI PART"), h[:8])
+	require.Equal(t, uint64(1), binary.LittleEndian.Uint64(h[24:32]))
+	require.Equal(t, uint64(totalLBAs-1), binary.LittleEndian.Uint64(h[32:40]))
+
+	// Header CRC verifies.
+	hdrLen := binary.LittleEndian.Uint32(h[12:16])
+	tmp := make([]byte, hdrLen)
+	copy(tmp, h[:hdrLen])
+	storedCRC := binary.LittleEndian.Uint32(tmp[16:20])
+	tmp[16], tmp[17], tmp[18], tmp[19] = 0, 0, 0, 0
+	require.Equal(t, storedCRC, crc32.ChecksumIEEE(tmp))
+
+	// Entries CRC matches the stored value.
+	entriesCRC := binary.LittleEndian.Uint32(h[88:92])
+	require.Equal(t, entriesCRC, crc32.ChecksumIEEE(layout.Entries))
+
+	// Backup header points back at the primary.
+	b := layout.BackupHeader
+	require.Equal(t, uint64(totalLBAs-1), binary.LittleEndian.Uint64(b[24:32]))
+	require.Equal(t, uint64(1), binary.LittleEndian.Uint64(b[32:40]))
+
+	// First entry carries the ESP type GUID and LBA range.
+	e := layout.Entries[:128]
+	require.Equal(t, GUID_EFI_SYSTEM[:], e[:16])
+	require.Equal(t, uint64(100), binary.LittleEndian.Uint64(e[32:40]))
+	require.Equal(t, uint64(199), binary.LittleEndian.Uint64(e[40:48]))
+
+	// Partition name is UTF-16LE.
+	require.Equal(t, byte('E'), e[56])
+	require.Equal(t, byte(0), e[57])
+}
+
+func TestGPTBuildErrors(t *testing.T) {
+	g := &GPT{}
+	_, err := g.Build(10) // far too small
+	require.Error(t, err)
+
+	tooMany := &GPT{Partitions: make([]GPTPartition, 200)}
+	_, err = tooMany.Build(100000)
+	require.Error(t, err)
+}
+
+func TestGPTDeterministicOutput(t *testing.T) {
+	build := func() []byte {
+		g := &GPT{Partitions: []GPTPartition{{TypeGUID: GUID_EFI_SYSTEM, FirstLBA: 1, LastLBA: 2, Name: "ESP"}}}
+		layout, err := g.Build(10000)
+		require.NoError(t, err)
+		return append(append([]byte{}, layout.PrimaryHeader...), layout.Entries...)
+	}
+	require.Equal(t, build(), build(), "GPT output should be reproducible")
+}

--- a/pkg/iso9660/validation/validation_test.go
+++ b/pkg/iso9660/validation/validation_test.go
@@ -1,0 +1,58 @@
+package validation
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateDCharacters(t *testing.T) {
+	require.NoError(t, ValidateDCharacters("ABC_123", false))
+	require.Error(t, ValidateDCharacters("lower", false))
+	require.Error(t, ValidateDCharacters("WITH SPACE", false))
+	require.Error(t, ValidateDCharacters("DOT.TXT", false))
+	require.NoError(t, ValidateDCharacters("DOT.TXT;1", true))
+}
+
+func TestValidateACharacters(t *testing.T) {
+	require.NoError(t, ValidateACharacters("HELLO WORLD 123!", false))
+	require.Error(t, ValidateACharacters("lower", false))
+	require.Error(t, ValidateACharacters("emoji \U0001F600", false))
+}
+
+func TestValidateCCharacters(t *testing.T) {
+	require.NoError(t, ValidateCCharacters("Mixed Case Name"))
+	require.Error(t, ValidateCCharacters("with/slash"))
+	require.Error(t, ValidateCCharacters("with*star"))
+	require.Error(t, ValidateCCharacters("ctrl\x01char"))
+	require.Error(t, ValidateCCharacters("outside \U0001F600 bmp"))
+	require.NoError(t, ValidateA1Characters("Same as C"))
+}
+
+func TestValidateFileIdentifierLevels(t *testing.T) {
+	// Relaxed level accepts anything.
+	require.NoError(t, ValidateFileIdentifier("anything at all!", false, InterchangeLevelRelaxed))
+
+	// Level 1: 8.3 for files, 8 for directories.
+	require.NoError(t, ValidateFileIdentifier("FILENAME.EXT", false, InterchangeLevel1))
+	require.NoError(t, ValidateFileIdentifier("F.E", false, InterchangeLevel1))
+	require.Error(t, ValidateFileIdentifier("TOOLONGNAME.EXT", false, InterchangeLevel1))
+	require.Error(t, ValidateFileIdentifier("FILE.LONG", false, InterchangeLevel1))
+	require.Error(t, ValidateFileIdentifier("lower.txt", false, InterchangeLevel1))
+	require.NoError(t, ValidateFileIdentifier("DIRNAME8", true, InterchangeLevel1))
+	require.Error(t, ValidateFileIdentifier("DIRNAME93", true, InterchangeLevel1))
+
+	// Level 2: 31-character budget.
+	long28 := strings.Repeat("A", 28)
+	require.NoError(t, ValidateFileIdentifier(long28+".EX", false, InterchangeLevel2))
+	require.Error(t, ValidateFileIdentifier(long28+".EXTX", false, InterchangeLevel2))
+	require.NoError(t, ValidateFileIdentifier(strings.Repeat("D", 31), true, InterchangeLevel2))
+	require.Error(t, ValidateFileIdentifier(strings.Repeat("D", 32), true, InterchangeLevel2))
+
+	// Directories may not contain separators at any level.
+	require.Error(t, ValidateFileIdentifier("DIR.EXT", true, InterchangeLevel2))
+
+	// Empty identifiers are invalid at strict levels.
+	require.Error(t, ValidateFileIdentifier("", false, InterchangeLevel1))
+}

--- a/pkg/udf/udf_test.go
+++ b/pkg/udf/udf_test.go
@@ -114,7 +114,7 @@ func buildTestImage(t *testing.T) []byte {
 	writeFE := func(block int, fileType byte, infoLength uint64, perms uint32, ads []shortAD) {
 		off := (partStart + block) * SectorSize
 		image[off+16+11] = fileType
-		image[off+16+18] = 0 // short_ad allocation
+		image[off+16+18] = 0                                 // short_ad allocation
 		binary.LittleEndian.PutUint32(image[off+36:], 1000)  // uid
 		binary.LittleEndian.PutUint32(image[off+40:], 1000)  // gid
 		binary.LittleEndian.PutUint32(image[off+44:], perms) // permissions


### PR DESCRIPTION
## Summary

The coverage push: direct unit tests for every load-bearing package that was previously exercised only transitively through the end-to-end suite. **Cross-package coverage: 65.7% → 74.3%**, with the remainder concentrated in trivial accessors (Type/Name/Description getters) and logging shims.

These are behavioral tests, not line-fillers: round-trips assert exact byte layouts and value recovery, error paths assert rejection of corrupt input, and semantic contracts (load-size saturation, CHS limits, GPT CRCs, deterministic output) are pinned.

### Bug found by the new tests
A non-bootable El Torito **section entry** (boot indicator 0x00) was parsed as end-of-catalog even when its section header promised more entries — silently dropping the rest of a multi-boot catalog. Entries promised by a header are now consumed before the end-of-catalog check applies. (0x00 is ambiguous by spec: it means both "not bootable" and "empty catalog space"; only the header count disambiguates.)

### Test additions by package
- **extensions**: RR marshal/unmarshal round-trips, symlink target variants, NM continuation splitting/reassembly, long-form TF, PosixMode↔parseFileMode inversion, SUSP entry shapes, unknown-entry tolerance + ST termination, CE decoding
- **boot**: catalog round-trips (single + multi-platform sections), validation-entry corruption rejection, SetExtent semantics incl. 16-bit saturation, ExtractBootImages, >128 KiB size reporting
- **directory**: record round-trips with SU data, flags, padding, Joliet UCS-2 identifiers, error paths, RR name/permission fallbacks
- **pathtable**: both byte orders, endianness divergence, build→reparse, error paths
- **systemarea**: MBR round-trip/rejection, CHS saturation, GPT CRC verification, backup header cross-refs, reproducibility
- **encoding**: both-byte-order mismatch detection, date/time bounds + timezone round-trips, UCS-2
- **filesystem**: entry content/hashes/extract, multi-extent reader edges
- **validation**: character sets, interchange levels
- **iso9660**: created-image getters (the historical nil-panic minefield), Joliet-preference branches, pristine passthrough, mutation error paths, AddLocalDirectory with symlinks/permissions

## Test plan
- Full suite green including `go test -race -count=1 ./...`
- gofmt/vet clean