### PR TITLE
Upload coverage reports to Codecov from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,3 +41,10 @@ jobs:
 
       - name: Coverage
         run: go test -count=1 -coverprofile=coverage.out -coverpkg=./... ./... && go tool cover -func=coverage.out | tail -1
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: coverage.out
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false


### PR DESCRIPTION
## Summary

The Codecov badge shows ~11% because **nothing ever uploads coverage** — the badge reflects stale data from long before the current test suite. Our CI computes `coverage.out` and prints the summary in the log, but the report never left the runner.

This adds the `codecov/codecov-action@v5` upload step using the repository's existing `CODECOV_TOKEN` secret (already configured — verified via the API). `fail_ci_if_error: false` keeps Codecov outages from breaking the build.

Once this merges and CI runs on main, the badge should update to the real number (~74% of statements across `./pkg/...`, measured with `-coverpkg`).

## Test plan
- CI on this PR will perform the first real upload; check the Codecov dashboard after the run